### PR TITLE
#1157 DatabaseServer parameter should be required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SharePointDsc
   - Updated all resources to load Utils module, which broke with the new CI
+- SPContentDatabase
+  - DatabaseServer is now a required parameter
 - SPConfigWizard
   - Updated checks in Set method to make sure the resource also runs when
     a language pack is installed

--- a/SharePointDsc/DSCResources/MSFT_SPContentDatabase/MSFT_SPContentDatabase.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPContentDatabase/MSFT_SPContentDatabase.psm1
@@ -108,7 +108,7 @@ function Set-TargetResource
         [System.String]
         $Name,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $DatabaseServer,
 
@@ -357,7 +357,7 @@ function Test-TargetResource
         [System.String]
         $Name,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $DatabaseServer,
 

--- a/SharePointDsc/DSCResources/MSFT_SPContentDatabase/MSFT_SPContentDatabase.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPContentDatabase/MSFT_SPContentDatabase.psm1
@@ -13,7 +13,7 @@ function Get-TargetResource
         [System.String]
         $Name,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $DatabaseServer,
 

--- a/SharePointDsc/DSCResources/MSFT_SPContentDatabase/MSFT_SPContentDatabase.schema.mof
+++ b/SharePointDsc/DSCResources/MSFT_SPContentDatabase/MSFT_SPContentDatabase.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_SPContentDatabase : OMI_BaseResource
 {
     [Key, Description("Specifies the name of the content database")] String Name;
-    [Write, Description("The name of the database server to host the content DB")] string DatabaseServer;
+    [Required, Description("The name of the database server to host the content DB")] string DatabaseServer;
     [Required, Description("The URL of the web application")] string WebAppUrl;
     [Write, Description("Should the database be enabled")] Boolean Enabled;
     [Write, Description("Specify the site collection warning limit for the content database")] Uint16 WarningSiteCount;


### PR DESCRIPTION
#### Pull Request (PR) description

The DatabaseServer parameter of SPContentDatabase was not previously marked as a required parameter; however, this parameter is fundamentally required within the SPContentDatabase module.  During new Content Database creation, this value is required to define creation state, and is equally required when the Content Database already exists (as it is needed to validate the state and determine if a Move operation is being defined).  Consideration remains the Move operations are not yet implemented in SharePoint DSC.

#### This Pull Request (PR) fixes the following issues

- Fixes #1157

#### Task list

- [X] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [X] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1158)
<!-- Reviewable:end -->
