### PR TITLE
SPTrustedRootAuthority: Enable specifying both path and thumbprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ resources:
   - Discontinued CrawlEverything, CrawlFirstOnly and null as allowable CrawlSetting
     values for a SharePoint based content source, requiring CrawlVirtualServers or
     CrawlSites
+- SPTrustedRootAuthority
+  - It's now possible to specify both CertificateFilePath and CertificateThumbprint
+    so that the certificate thumbprint can be verified before importing.
 - SPUserProfileServiceApp
   - Changed the MySiteHostLocation parameter to a required parameter
 - SPWebAppAuthentication

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -13,7 +13,7 @@
     Plaster                     = 'latest'
     ModuleBuilder               = '1.0.0'
     ChangelogManagement         = 'latest'
-    Sampler                     = '0.104.0'
+    Sampler                     = 'latest'
     'DscResource.Test'          = 'latest'
     'DscResource.AnalyzerRules' = 'latest'
     'DscResource.DocGenerator'  = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -13,7 +13,7 @@
     Plaster                     = 'latest'
     ModuleBuilder               = '1.0.0'
     ChangelogManagement         = 'latest'
-    Sampler                     = 'latest'
+    Sampler                     = '0.104.0'
     'DscResource.Test'          = 'latest'
     'DscResource.AnalyzerRules' = 'latest'
     'DscResource.DocGenerator'  = 'latest'

--- a/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/readme.md
+++ b/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/readme.md
@@ -7,7 +7,10 @@ This resource is used to create or remove SPTrustedIdentityTokenIssuer in a
 SharePoint farm.
 
 Either parameter SigningCertificateThumbPrint or SigningCertificateFilePath
-must be set, but not both.
+must be set. If specifying both SigningCertificateThumbPrint and
+SigningCertificateFilePath, the certificate thumbprint will be verified
+with the specified SigningCertificateThumbPrint. If the thumbprints doesn't
+match an exception will be thrown.
 
 The SigningCertificateThumbPrint must be the thumbprint of the signing
 certificate stored in the certificate store LocalMachine\My of the server


### PR DESCRIPTION
#### Pull Request (PR) description

Added possibility to specify path and thumbprint for the certificate so that it is impossible to inadvertently change the certificate on disk either by accident or maliciously. The certificate will be verified to match the specified thumbprint when importing using bot parameters.

#### This Pull Request (PR) fixes the following issues

N/A

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1188)
<!-- Reviewable:end -->
