### PR TITLE
SPTrustedSecurityTokenIssuer: Added support for specifying both thumbprint and path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ resources:
   - Discontinued CrawlEverything, CrawlFirstOnly and null as allowable CrawlSetting
     values for a SharePoint based content source, requiring CrawlVirtualServers or
     CrawlSites
+- SPTrustedSecurityTokenIssuer
+  - It's now possible to specify both SigningCertificateFilePath and
+    SigningCertificateThumbprint so that the certificate thumbprint can be verified
+    before importing.
 - SPUserProfileServiceApp
   - Changed the MySiteHostLocation parameter to a required parameter
 - SPWebAppAuthentication

--- a/SharePointDsc/DSCResources/MSFT_SPTrustedSecurityTokenIssuer/readme.md
+++ b/SharePointDsc/DSCResources/MSFT_SPTrustedSecurityTokenIssuer/readme.md
@@ -9,10 +9,16 @@ a SharePoint farm.
 It requires to specify either a MetadataEndPoint or a certificate.
 
 The certificate can be specified by setting either parameter
-SigningCertificateThumbPrint or SigningCertificateFilePath, but not both.
+SigningCertificateThumbPrint or SigningCertificateFilePath. If specifying
+both SigningCertificateThumbPrint and SigningCertificateFilePath, the
+certificate thumbprint from the file will be verified with the specified
+SigningCertificateThumbPrint. If the thumbprints doesn't match an exception
+will be thrown when configuring the resource.
 
 The SigningCertificateThumbPrint must be the thumbprint of the signing
-certificate stored in the certificate store LocalMachine\My of the server
+certificate stored in the certificate store LocalMachine\My of the server.
+If SigningCertificateFilePath is also specified it must be the same
+thumbrint as the certificate file.
 
 The SigningCertificateFilePath must be the file path to the public key of
 the signing certificate.


### PR DESCRIPTION
#### Pull Request (PR) description

Added possibility to specify path and thumbprint for the certificate so that it is impossible to inadvertently change the certificate on disk either by accident or maliciously. The certificate will be verified to match the specified thumbprint when importing using bot parameters.

#### This Pull Request (PR) fixes the following issues

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1189)
<!-- Reviewable:end -->
