### PR TITLE
SharePointDSC General: Fixed duplicate key issue when testing resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SharePointDsc generic
+  - Fixed an issue where Test-Resource would throw an error due to duplicate
+    keys when a desired value is of type CimInstance[] and multiple values
+    are specified.
+
 ## [4.0.0] - 2020-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - SharePointDsc generic
-  - Fixed an issue where Test-Resource would throw an error due to duplicate
+  - Fixed an issue where Test-SPDscParameterState would throw an error due to duplicate
     keys when a desired value is of type CimInstance[] and multiple values
     are specified.
 

--- a/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
+++ b/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
@@ -123,7 +123,7 @@ function Compare-PSCustomObjectArrays
                 Desired      = $DesiredEntry.$KeyProperty
                 Current      = $null
             }
-            $DriftedProperties += $DesiredEntry
+            $DriftedProperties += $result
         }
         else
         {
@@ -1004,9 +1004,13 @@ function Test-SPDscParameterState
                             {
                                 foreach ($item in $arrayCompare)
                                 {
-                                    $EventValue = "<CurrentValue>[$($item.PropertyName)]$($item.CurrentValue)</CurrentValue>"
-                                    $EventValue += "<DesiredValue>[$($item.PropertyName)]$($item.DesiredValue)</DesiredValue>"
-                                    $DriftedParameters.Add($fieldName, $EventValue)
+                                    $EventValue = "<CurrentValue>[$($item.PropertyName)]$($item.Current)</CurrentValue>"
+                                    $EventValue += "<DesiredValue>[$($item.PropertyName)]$($item.Desired)</DesiredValue>"
+                                    if (-not $DriftedParameters.ContainsKey($fieldName))
+                                    {
+                                        $DriftedParameters.Add($fieldName, @())
+                                    }
+                                    $DriftedParameters[$fieldName] = $DriftedParameters[$fieldName] += $EventValue
                                 }
                                 $returnValue = $false
                             }
@@ -1179,9 +1183,13 @@ function Test-SPDscParameterState
                                     {
                                         foreach ($item in $arrayCompare)
                                         {
-                                            $EventValue = "<CurrentValue>[$($item.PropertyName)]$($item.CurrentValue)</CurrentValue>"
-                                            $EventValue += "<DesiredValue>[$($item.PropertyName)]$($item.DesiredValue)</DesiredValue>"
-                                            $DriftedParameters.Add($fieldName, $EventValue)
+                                            $EventValue = "<CurrentValue>[$($item.PropertyName)]$($item.Current)</CurrentValue>"
+                                            $EventValue += "<DesiredValue>[$($item.PropertyName)]$($item.Desired)</DesiredValue>"
+                                            if (-not $DriftedParameters.ContainsKey($fieldName))
+                                            {
+                                                $DriftedParameters.Add($fieldName, @())
+                                            }
+                                            $DriftedParameters[$fieldName] = $DriftedParameters[$fieldName] += $EventValue
                                         }
                                         $returnValue = $false
                                     }


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes an issue where Test-Resource would throw an error due to duplicate keys when a desired value is of type CimInstance[] and multiple values are specified, and the values are not in desired state.

#### This Pull Request (PR) fixes the following issues

N/A

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1194)
<!-- Reviewable:end -->
