### PR TITLE
First run of DSC fails at SPTrustedIdentityTokenIssuer, if property ClaimProviderName is omitted/null/empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- SPTrustedIdentityTokenIssuer
+  - Run Get-SPClaimProvider only if property ClaimProviderName is omitted/null/empty.
+
 ### Fixed
 
 - SharePointDsc

--- a/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
@@ -294,13 +294,16 @@ function Set-TargetResource
                     throw "SharePoint failed to create the SPTrustedIdentityTokenIssuer."
                 }
 
-                $claimProvider = (Get-SPClaimProvider | Where-Object -FilterScript {
+                if ($false -eq [String]::IsNullOrWhiteSpace($params.ClaimProviderName))
+                {
+                    $claimProvider = (Get-SPClaimProvider | Where-Object -FilterScript {
                         $_.DisplayName -eq $params.ClaimProviderName
                     })
-                if ($null -eq $claimProvider)
-                {
-                    $trust.ClaimProviderName = $params.ClaimProviderName
-                }
+                    if ($null -eq $claimProvider)
+                    {
+                        $trust.ClaimProviderName = $params.ClaimProviderName
+                    }
+                }               
 
                 if ($params.ProviderSignOutUri)
                 {

--- a/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
@@ -297,13 +297,13 @@ function Set-TargetResource
                 if ($false -eq [String]::IsNullOrWhiteSpace($params.ClaimProviderName))
                 {
                     $claimProvider = (Get-SPClaimProvider | Where-Object -FilterScript {
-                        $_.DisplayName -eq $params.ClaimProviderName
-                    })
+                            $_.DisplayName -eq $params.ClaimProviderName
+                        })
                     if ($null -eq $claimProvider)
                     {
                         $trust.ClaimProviderName = $params.ClaimProviderName
                     }
-                }               
+                }
 
                 if ($params.ProviderSignOutUri)
                 {


### PR DESCRIPTION
#### Pull Request (PR) description

In function Set-TargetResource of resource SPTrustedIdentityTokenIssuer, test if property ClaimProviderName is omitted/null/empty, to call Get-SPClaimProvider only if necessary.

#### This Pull Request (PR) fixes the following issues

Fixes #1223 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1224)
<!-- Reviewable:end -->
