### PR TITLE
Property ClaimProviderName is no longer actually set in resource SPTrustedIdentityTokenIssuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SPTrustedIdentityTokenIssuer
+  - Property ClaimProviderName is never set
+
 ### Added
 
 - SPProductUpdate

--- a/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
@@ -299,7 +299,7 @@ function Set-TargetResource
                     $claimProvider = (Get-SPClaimProvider | Where-Object -FilterScript {
                             $_.DisplayName -eq $params.ClaimProviderName
                         })
-                    if ($null -eq $claimProvider)
+                    if ($null -ne $claimProvider)
                     {
                         $trust.ClaimProviderName = $params.ClaimProviderName
                     }


### PR DESCRIPTION
#### Pull Request (PR) description

Commit https://github.com/dsccommunity/SharePointDsc/commit/5d914d766663dd7b507fbcf4f7edf5aac016a472 introduced a regression in resource SPTrustedIdentityTokenIssuer:
Property ClaimProviderName is no longer actually set by Set-TargetResource, due to a bad test.

#### This Pull Request (PR) fixes the following issues

- Fixes #1227

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1228)
<!-- Reviewable:end -->
