### PR TITLE
SPFarm: Added possibility to specify port number in the CentralAdministrationUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - SharePointDsc
   - Changed ModuleBuilder module to latest version
+- SPFarm
+  - Added support for specifying port number in the CentralAdministrationUrl parameter.
+    If CentralAdministrationPort is also specified both port numbers must match.
 
 ### Fixed
 

--- a/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
@@ -567,7 +567,7 @@ function Set-TargetResource
 
                     $isCentralAdminUrlHttps = (([System.Uri]$params.CentralAdministrationUrl).Scheme -eq 'https')
 
-                    $desiredUri = [System.Uri]("{0}:{1}" -f $params.CentralAdministrationUrl.TrimEnd('/'), $params.CentralAdministrationPort)
+                    $desiredUri = [System.Uri]($params.CentralAdministrationUrl.TrimEnd('/'))
                     $currentUri = [System.Uri]$centralAdminSite.Url
                     if ($desiredUri.AbsoluteUri -ne $currentUri.AbsoluteUri)
                     {
@@ -981,7 +981,7 @@ function Set-TargetResource
                         $reprovisionCentralAdmin = $false
                         $isCentralAdminUrlHttps = (([System.Uri]$params.CentralAdministrationUrl).Scheme -eq 'https')
 
-                        $desiredUri = [System.Uri]("{0}:{1}" -f $params.CentralAdministrationUrl.TrimEnd('/'), $params.CentralAdministrationPort)
+                        $desiredUri = [System.Uri]($params.CentralAdministrationUrl.TrimEnd('/'))
                         $currentUri = [System.Uri]$centralAdminSite.Url
 
                         if ($isCentralAdminUrlHttps)

--- a/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
@@ -215,7 +215,7 @@ function Get-TargetResource
             $ca = Get-SPServiceInstance -Server $env:ComputerName
             if ($null -ne $ca)
             {
-                $ca = $ca | Where-Object -Filterscript {
+                $ca = $ca | Where-Object -FilterScript {
                     $_.GetType().Name -eq "SPWebServiceInstance" -and
                     $_.Name -eq "WSS_Administration" -and
                     $_.Status -eq "Online"
@@ -440,9 +440,14 @@ function Set-TargetResource
             {
                 throw "CentralAdministrationUrl is not a valid URI. It should include the scheme (http/https) and address."
             }
-            if ($CentralAdministrationUrl -match ':\d+')
+
+            if ($PSBoundParameters.ContainsKey("CentralAdministrationPort"))
             {
-                throw "CentralAdministrationUrl should not specify port. Use CentralAdministrationPort instead."
+                if ($uri.Port -ne $CentralAdministrationPort)
+                {
+                    throw ("CentralAdministrationPort does not match port number specified in CentralAdministrationUrl. " +
+                        "Either make the values match or don't specify CentralAdministrationPort.")
+                }
             }
         }
     }
@@ -1177,12 +1182,14 @@ function Test-TargetResource
                 throw ("CentralAdministrationUrl is not a valid URI. It should " +
                     "include the scheme (http/https) and address.")
             }
-            # TODO: should we allow port here as long as either the port matches CentralAdministrationPort
-            #       or CentralAdministrationPort is not specified?
-            if ($CentralAdministrationUrl -match ':\d+')
+
+            if ($PSBoundParameters.ContainsKey("CentralAdministrationPort"))
             {
-                throw ("CentralAdministrationUrl should not specify port. Use " +
-                    "CentralAdministrationPort instead.")
+                if ($uri.Port -ne $CentralAdministrationPort)
+                {
+                    throw ("CentralAdministrationPort does not match port number specified in CentralAdministrationUrl. " +
+                        "Either make the values match or don't specify CentralAdministrationPort.")
+                }
             }
         }
     }

--- a/SharePointDsc/DSCResources/MSFT_SPFarm/Readme.md
+++ b/SharePointDsc/DSCResources/MSFT_SPFarm/Readme.md
@@ -25,7 +25,7 @@ The port of the Central Admin website can be set by using the
 CentralAdministrationPort property. If this is not defined, the site will be
 provisioned on port 9999 unless the CentralAdministrationUrl property is
 specified and begins with https, in which case it will default to port 443.
-The prot number in CentralAdministrationPort and CentralAdministrationUrl must
+The port number in CentralAdministrationPort and CentralAdministrationUrl must
 match if both parameters are specified. It is not recommended to include port
 number 80 and 443 in the CentralAdministrationUrl parameter. This will
 automatically follow the URL shceme http (80) and https (443) specified.

--- a/SharePointDsc/DSCResources/MSFT_SPFarm/Readme.md
+++ b/SharePointDsc/DSCResources/MSFT_SPFarm/Readme.md
@@ -25,6 +25,13 @@ The port of the Central Admin website can be set by using the
 CentralAdministrationPort property. If this is not defined, the site will be
 provisioned on port 9999 unless the CentralAdministrationUrl property is
 specified and begins with https, in which case it will default to port 443.
+The prot number in CentralAdministrationPort and CentralAdministrationUrl must
+match if both parameters are specified. It is not recommended to include port
+number 80 and 443 in the CentralAdministrationUrl parameter. This will
+automatically follow the URL shceme http (80) and https (443) specified.
+CentralAdministrationPort is an optional parameter and can be omitted if the
+port is specified in CentralAdministrationUrl, or if default ports for
+http/https is used (no port is required to be specified).
 However, this setting will not impact existing deployments that already have
 Central Admin provisioned on another port. Also, when a farm is created, the
 current behavior is to not enroll the server as a cache server (which is the


### PR DESCRIPTION
#### Pull Request (PR) description

Added possibility to specify port number in the CentralAdministrationUrl parameter. Without this capability it is impossible to get a passing test for Central Administration site provisioned on a vanity URL and a port different from the URL scheme default port (80/443)

#### This Pull Request (PR) fixes the following issues

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1238)
<!-- Reviewable:end -->
