### PR TITLE
SPTrustedIdentityTokenIssuer: Do not set property ProviderSignOutUri in SP2013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- SPTrustedIdentityTokenIssuer
+  - Do not set property ProviderSignOutUri in SharePoint 2013 as it does
+  not exist
+
 ### Fixed
 
 - SPWebAppPolicy

--- a/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
@@ -342,7 +342,12 @@ function Set-TargetResource
 
                 if ($params.ProviderSignOutUri)
                 {
-                    $trust.ProviderSignOutUri = New-Object -TypeName System.Uri ($params.ProviderSignOutUri)
+                    $installedVersion = Get-SPDscInstalledProductVersion
+                    # This property does not exist in SharePoint 2013
+                    if ($installedVersion.FileMajorPart -ne 15)
+                    {
+                        $trust.ProviderSignOutUri = New-Object -TypeName System.Uri ($params.ProviderSignOutUri)
+                    }
                 }
                 $trust.Update()
             }


### PR DESCRIPTION
#### Pull Request (PR) description

Property SPTrustedLoginProvider.ProviderSignOutUri does not exist in SharePoint 2013 and it will cause an error if script attempts to set it.
So I added a test to not set it if current platform is SharePoint 2013.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1270)
<!-- Reviewable:end -->
