### PR TITLE
SPUserProfileServiceApp: Changed MySiteHostLocation parameter to not be mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- SPUserProfileServiceApp
+  - Changed MySiteHostLocation parameter mandatory=$false
+  - Added validation to Set function for testing if SiteNamingConflictResolution parameter is defined then
+    also MySiteHostLocation parameters has to be because it is a mandatory parameter in the parameter set of New-SPProfileServiceApplication when SiteNamingConflictResolution is used
+  - Added "MySiteHostLocation" to Test-SPDscParameterState function in Test-TargetResource
+
+
 ### Fixed
 
 - SPWebAppPolicy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Do not set property ProviderSignOutUri in SharePoint 2013 as it does
   not exist
 - SPUserProfileServiceApp
-  - Changed MySiteHostLocation parameter mandatory=$false
+  - Changed MySiteHostLocation to not be mandatory
   - Added validation to Set function for testing if SiteNamingConflictResolution parameter
     is defined then also MySiteHostLocation parameters has to be because it is a mandatory
     parameter in the parameter set of New-SPProfileServiceApplication when

--- a/SharePointDsc/DSCResources/MSFT_SPUserProfileServiceApp/MSFT_SPUserProfileServiceApp.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPUserProfileServiceApp/MSFT_SPUserProfileServiceApp.psm1
@@ -16,7 +16,7 @@ function Get-TargetResource
         [System.String]
         $ApplicationPool,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [System.String]
         $MySiteHostLocation,
 
@@ -280,7 +280,7 @@ function Set-TargetResource
         [System.String]
         $ApplicationPool,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [System.String]
         $MySiteHostLocation,
 
@@ -675,7 +675,7 @@ function Test-TargetResource
         [System.String]
         $ApplicationPool,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter()]
         [System.String]
         $MySiteHostLocation,
 

--- a/SharePointDsc/DSCResources/MSFT_SPUserProfileServiceApp/MSFT_SPUserProfileServiceApp.schema.mof
+++ b/SharePointDsc/DSCResources/MSFT_SPUserProfileServiceApp/MSFT_SPUserProfileServiceApp.schema.mof
@@ -4,7 +4,7 @@ class MSFT_SPUserProfileServiceApp : OMI_BaseResource
     [Key, Description("The name of the user profile service")] string Name;
     [Write, Description("The proxy name, if not specified will be /Name of service app/ Proxy")] string ProxyName;
     [Required, Description("The name of the application pool to run the service app in")] string ApplicationPool;
-    [Required, Description("The URL of the my site host collection")] string MySiteHostLocation;
+    [Write, Description("The URL of the my site host collection")] string MySiteHostLocation;
     [Write, Description("The Managed Path of the my site sites")] string MySiteManagedPath;
     [Write, Description("The name of the profile database")] string ProfileDBName;
     [Write, Description("The name of the server to host the profile database")] string ProfileDBServer;

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPUserProfileServiceApp.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPUserProfileServiceApp.Tests.ps1
@@ -33,7 +33,7 @@ function Invoke-TestSetup
 
     $script:testEnvironment = Initialize-TestEnvironment `
         -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceFullName `
+        -DscResourceName $script:DSCResourceFullName `
         -ResourceType 'Mof' `
         -TestType 'Unit'
 }
@@ -50,7 +50,7 @@ try
     InModuleScope -ModuleName $script:DSCResourceFullName -ScriptBlock {
         Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             BeforeAll {
-                Invoke-Command -ScriptBlock $Global:SPDscHelper.InitializeScript -NoNewScope
+                Invoke-Command -Scriptblock $Global:SPDscHelper.InitializeScript -NoNewScope
 
                 # Initialize tests
                 $getTypeFullName = "Microsoft.Office.Server.Administration.UserProfileApplication"
@@ -73,6 +73,17 @@ try
                                 public class UserProfileManager {
                                     public UserProfileManager(System.Object a)
                                     {
+                                    }
+
+                                    public string MySiteHostUrl
+                                    {
+                                        get
+                                        {
+                                            return "https://my.contoso.com";
+                                        }
+                                        set
+                                        {
+                                        }
                                     }
 
                                     public string PersonalSiteFormat


### PR DESCRIPTION
#### Pull Request (PR) description

SPUserProfileServiceApp
  - Changed MySiteHostLocation parameter mandatory=$false
  - Added validation to Set function for testing if SiteNamingConflictResolution parameter is defined then
    also MySiteHostLocation parameters has to be because it is a mandatory parameter in the parameter set of New-SPProfileServiceApplication when SiteNamingConflictResolution is used
  - Added "MySiteHostLocation" to Test-SPDscParameterState function in Test-TargetResource

#### This Pull Request (PR) fixes the following issues
- Fixes #1267 


#### Task list

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1275)
<!-- Reviewable:end -->
