### PR TITLE
MSFT_SPSecurityTokenServiceConfig: Added properties FormsTokenLifetime, WindowsTokenLifetime and LogonTokenCacheExpirationWindow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on and uses the types of changes according to [Keep a Change
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- SPSecurityTokenServiceConfig
+  - Added support for LogonTokenCacheExpirationWindow, WindowsTokenLifetime and FormsTokenLifetime settings
 
 ## [4.6.0] - 2021-04-02
 

--- a/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/MSFT_SPSecurityTokenServiceConfig.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/MSFT_SPSecurityTokenServiceConfig.psm1
@@ -54,13 +54,15 @@ function Get-TargetResource
         $Ensure = "Present"
     )
 
+    Write-Verbose -Message "Getting Security Token Service Configuration"
+
     if ($PSBoundParameters.ContainsKey("LogonTokenCacheExpirationWindow") -eq $true -and `
         $PSBoundParameters.ContainsKey("WindowsTokenLifetime") -eq $true)
     {
-        if ($PSBoundParameters.LogonTokenCacheExpirationWindow -le $PSBoundParameters.WindowsTokenLifetime)
+        if ($PSBoundParameters.LogonTokenCacheExpirationWindow -ge $PSBoundParameters.WindowsTokenLifetime)
         {
-            $message = ("Setting LogonTokenCacheExpirationWindow to a value lower or equal as WindowsTokenLifetime ist not supported. " + `
-                    "Please set LogonTokenCacheExpirationWindow to value higher than WindowsTokenLifetime")
+            $message = ("Setting LogonTokenCacheExpirationWindow to a value higher or equal as WindowsTokenLifetime is not supported. " + `
+                    "Please set LogonTokenCacheExpirationWindow to value lower as WindowsTokenLifetime")
             Add-SPDscEvent -Message $message `
                 -EntryType 'Error' `
                 -EventID 100 `
@@ -74,8 +76,8 @@ function Get-TargetResource
     {
         if ($PSBoundParameters.LogonTokenCacheExpirationWindow -le $PSBoundParameters.FormsTokenLifetime)
         {
-            $message = ("Setting LogonTokenCacheExpirationWindow to a value lower or equal as FormsTokenLifetime ist not supported. " + `
-                    "Please set LogonTokenCacheExpirationWindow to value higher than FormsTokenLifetime")
+            $message = ("Setting LogonTokenCacheExpirationWindow to a value higher or equal as FormsTokenLifetime is not supported. " + `
+                    "Please set LogonTokenCacheExpirationWindow to value lower as FormsTokenLifetime")
             Add-SPDscEvent -Message $message `
                 -EntryType 'Error' `
                 -EventID 100 `
@@ -84,28 +86,12 @@ function Get-TargetResource
         }
     }
 
-    Write-Verbose -Message "Getting Security Token Service Configuration"
-
     $result = Invoke-SPDscCommand -Credential $InstallAccount `
         -Arguments $PSBoundParameters `
         -ScriptBlock {
         $params = $args[0]
 
         $config = Get-SPSecurityTokenServiceConfig
-
-        if ($null -ne $config)
-        {
-            if ( ($params.LogonTokenCacheExpirationWindow -le $config.FormsTokenLifetime.TotalMinutes) -or ($params.LogonTokenCacheExpirationWindow -le $config.WindowsTokenLifetime.TotalMinutes) )
-            {
-                $message = ("Setting LogonTokenCacheExpirationWindow to a value lower or equal as WindowsTokenLifetime or FormsTokenLifetime ist not supported. " + `
-                            "Please set LogonTokenCacheExpirationWindow to value higher than WindowsTokenLifetime and FormsTokenLifetime")
-                    Add-SPDscEvent -Message $message `
-                        -EntryType 'Error' `
-                        -EventID 100 `
-                        -Source $MyInvocation.MyCommand.Source
-                    throw $message
-            }
-        }
 
         $nullReturn = @{
             IsSingleInstance                = "Yes"
@@ -119,6 +105,7 @@ function Get-TargetResource
             LogonTokenCacheExpirationWindow = $params.LogonTokenCacheExpirationWindow
             Ensure                          = "Absent"
         }
+
         if ($null -eq $config)
         {
             return $nullReturn
@@ -208,10 +195,10 @@ function Set-TargetResource
     if ($PSBoundParameters.ContainsKey("LogonTokenCacheExpirationWindow") -eq $true -and `
         $PSBoundParameters.ContainsKey("WindowsTokenLifetime") -eq $true)
     {
-        if ($PSBoundParameters.LogonTokenCacheExpirationWindow -le $PSBoundParameters.WindowsTokenLifetime)
+        if ($PSBoundParameters.LogonTokenCacheExpirationWindow -ge $PSBoundParameters.WindowsTokenLifetime)
         {
-            $message = ("Setting LogonTokenCacheExpirationWindow to a value lower or equal as WindowsTokenLifetime ist not supported. " + `
-                    "Please set LogonTokenCacheExpirationWindow to value higher than WindowsTokenLifetime")
+            $message = ("Setting LogonTokenCacheExpirationWindow to a value higher or equal as WindowsTokenLifetime is not supported. " + `
+                    "Please set LogonTokenCacheExpirationWindow to value lower as WindowsTokenLifetime")
             Add-SPDscEvent -Message $message `
                 -EntryType 'Error' `
                 -EventID 100 `
@@ -223,10 +210,10 @@ function Set-TargetResource
     if ($PSBoundParameters.ContainsKey("LogonTokenCacheExpirationWindow") -eq $true -and `
         $PSBoundParameters.ContainsKey("FormsTokenLifetime") -eq $true)
     {
-        if ($PSBoundParameters.LogonTokenCacheExpirationWindow -le $PSBoundParameters.FormsTokenLifetime)
+        if ($PSBoundParameters.LogonTokenCacheExpirationWindow -ge $PSBoundParameters.FormsTokenLifetime)
         {
-            $message = ("Setting LogonTokenCacheExpirationWindow to a value lower or equal as FormsTokenLifetime ist not supported. " + `
-                    "Please set LogonTokenCacheExpirationWindow to value higher than FormsTokenLifetime")
+            $message = ("Setting LogonTokenCacheExpirationWindow to a value higher or equal as FormsTokenLifetime is not supported. " + `
+                    "Please set LogonTokenCacheExpirationWindow to value lower as FormsTokenLifetime")
             Add-SPDscEvent -Message $message `
                 -EntryType 'Error' `
                 -EventID 100 `
@@ -274,10 +261,10 @@ function Set-TargetResource
 
         if ($params.ContainsKey("LogonTokenCacheExpirationWindow"))
         {
-            if (!($params.ContainsKey("WindowsTokenLifetime")) -and ($params.LogonTokenCacheExpirationWindow -le $config.WindowsTokenLifetime.TotalMinutes))
+            if (-not $params.ContainsKey("WindowsTokenLifetime") -and ($params.LogonTokenCacheExpirationWindow -ge $config.WindowsTokenLifetime.TotalMinutes))
             {
-                $message = ("Setting LogonTokenCacheExpirationWindow to a value lower or equal as WindowsTokenLifetime ist not supported. " + `
-                            "Please set LogonTokenCacheExpirationWindow to value higher than WindowsTokenLifetime")
+                $message = ("Setting LogonTokenCacheExpirationWindow to a value higher or equal as WindowsTokenLifetime is not supported. " + `
+                            "Please set LogonTokenCacheExpirationWindow to value lower as WindowsTokenLifetime")
                 Add-SPDscEvent -Message $message `
                     -EntryType 'Error' `
                     -EventID 100 `
@@ -285,10 +272,10 @@ function Set-TargetResource
                 throw $message
             }
 
-            if (!($params.ContainsKey("FormsTokenLifetime")) -and ($params.LogonTokenCacheExpirationWindow -le $config.FormsTokenLifetime.TotalMinutes))
+            if (-not $params.ContainsKey("FormsTokenLifetime") -and ($params.LogonTokenCacheExpirationWindow -ge $config.FormsTokenLifetime.TotalMinutes))
             {
-                $message = ("Setting LogonTokenCacheExpirationWindow to a value lower or equal as FormsTokenLifetime ist not supported. " + `
-                            "Please set LogonTokenCacheExpirationWindow to value higher than FormsTokenLifetime")
+                $message = ("Setting LogonTokenCacheExpirationWindow to a value higher or equal as FormsTokenLifetime is not supported. " + `
+                            "Please set LogonTokenCacheExpirationWindow to value lower as FormsTokenLifetime")
                 Add-SPDscEvent -Message $message `
                     -EntryType 'Error' `
                     -EventID 100 `

--- a/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/MSFT_SPSecurityTokenServiceConfig.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/MSFT_SPSecurityTokenServiceConfig.psm1
@@ -74,7 +74,7 @@ function Get-TargetResource
     if ($PSBoundParameters.ContainsKey("LogonTokenCacheExpirationWindow") -eq $true -and `
         $PSBoundParameters.ContainsKey("FormsTokenLifetime") -eq $true)
     {
-        if ($PSBoundParameters.LogonTokenCacheExpirationWindow -le $PSBoundParameters.FormsTokenLifetime)
+        if ($PSBoundParameters.LogonTokenCacheExpirationWindow -ge $PSBoundParameters.FormsTokenLifetime)
         {
             $message = ("Setting LogonTokenCacheExpirationWindow to a value higher or equal as FormsTokenLifetime is not supported. " + `
                     "Please set LogonTokenCacheExpirationWindow to value lower as FormsTokenLifetime")

--- a/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/MSFT_SPSecurityTokenServiceConfig.schema.mof
+++ b/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/MSFT_SPSecurityTokenServiceConfig.schema.mof
@@ -7,9 +7,9 @@ class MSFT_SPSecurityTokenServiceConfig : OMI_BaseResource
     [Write, Description("True set the security token service to use cookies")] Boolean UseSessionCookies;
     [Write, Description("True set the security token service to allow OAuth over HTTP")] Boolean AllowOAuthOverHttp;
     [Write, Description("True set the security token service to allow metadata exchange over HTTP")] Boolean AllowMetadataOverHttp;
-    [Write, Description("Timespan in minutes to set FormsTokenLifetime")] Int32 FormsTokenLifetime;
-    [Write, Description("Timespan in minutes to set WindowsTokenLifetime")] Int32 WindowsTokenLifetime;
-    [Write, Description("Timespan in minutes to set LogonTokenCacheExpirationWindow")] Int32 LogonTokenCacheExpirationWindow;
+    [Write, Description("Timespan in minutes to set FormsTokenLifetime")] UInt32 FormsTokenLifetime;
+    [Write, Description("Timespan in minutes to set WindowsTokenLifetime")] UInt32 WindowsTokenLifetime;
+    [Write, Description("Timespan in minutes to set LogonTokenCacheExpirationWindow")] UInt32 LogonTokenCacheExpirationWindow;
     [Write, Description("Present ensures the configurations are applied"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };

--- a/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/MSFT_SPSecurityTokenServiceConfig.schema.mof
+++ b/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/MSFT_SPSecurityTokenServiceConfig.schema.mof
@@ -7,6 +7,9 @@ class MSFT_SPSecurityTokenServiceConfig : OMI_BaseResource
     [Write, Description("True set the security token service to use cookies")] Boolean UseSessionCookies;
     [Write, Description("True set the security token service to allow OAuth over HTTP")] Boolean AllowOAuthOverHttp;
     [Write, Description("True set the security token service to allow metadata exchange over HTTP")] Boolean AllowMetadataOverHttp;
+    [Write, Description("Timespan in minutes to set FormsTokenLifetime")] Int32 FormsTokenLifetime;
+    [Write, Description("Timespan in minutes to set WindowsTokenLifetime")] Int32 WindowsTokenLifetime;
+    [Write, Description("Timespan in minutes to set LogonTokenCacheExpirationWindow")] Int32 LogonTokenCacheExpirationWindow;
     [Write, Description("Present ensures the configurations are applied"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };

--- a/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/readme.md
+++ b/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/readme.md
@@ -8,6 +8,6 @@ the local SharePoint farm. Using Ensure equals to Absent is not supported.
 This resource can only apply configuration, not ensure they don't exist.
 
 This resource is also able to set the properties FormsTokenLifetime, WindowsTokenLifetime and LogonTokenCacheExpirationWindow.
-It checks for values leading to “The context has expired and can no longer be used.” errors.
+It checks for values leading to "The context has expired and can no longer be used." errors.
 The value for LogonTokenCacheExpirationWindow must be higher than the values for FormsTokenLifetime and WindowsTokenLifetime,
 it will return an error if not.

--- a/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/readme.md
+++ b/SharePointDsc/DSCResources/MSFT_SPSecurityTokenServiceConfig/readme.md
@@ -6,3 +6,8 @@
 This resource is responsible for configuring the Security Token Service within
 the local SharePoint farm. Using Ensure equals to Absent is not supported.
 This resource can only apply configuration, not ensure they don't exist.
+
+This resource is also able to set the properties FormsTokenLifetime, WindowsTokenLifetime and LogonTokenCacheExpirationWindow.
+It checks for values leading to “The context has expired and can no longer be used.” errors.
+The value for LogonTokenCacheExpirationWindow must be higher than the values for FormsTokenLifetime and WindowsTokenLifetime,
+it will return an error if not.


### PR DESCRIPTION
#### Pull Request (PR) description

This resource is also able to set the properties FormsTokenLifetime, WindowsTokenLifetime and LogonTokenCacheExpirationWindow.
It checks for values leading to “The context has expired and can no longer be used.” errors.
The value for LogonTokenCacheExpirationWindow must be higher than the values for FormsTokenLifetime and WindowsTokenLifetime,
it will return an error if not.

#### This Pull Request (PR) fixes the following issues

- Fixes 1302

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1307)
<!-- Reviewable:end -->
