### PR TITLE
SPFarm: Suppress a useless 5 minutes sleep triggered once a server joined the farm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SPFarm
   - Suppress a useless reboot that was triggered once a server joined the farm
+  - Suppress a useless 5 minutes sleep triggered once a server joined the farm
 
 ## [5.0.0] - 2021-12-17
 

--- a/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
@@ -1235,10 +1235,6 @@ function Set-TargetResource
         {
             Write-Verbose -Message "Starting timer service"
             Start-Service -Name sptimerv4
-
-            Write-Verbose -Message ("Pausing for 5 minutes to allow the timer service to " +
-                "fully provision the server")
-            Start-Sleep -Seconds 300
             Write-Verbose -Message ("Join farm complete")
         }
     }


### PR DESCRIPTION
#### Pull Request (PR) description

Suppress a useless 5 minutes sleep triggered once a server joined the farm.
I tested it against SharePoint Subscription / 2019 / 2016 / 2013 and noticed no side effect

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1372)
<!-- Reviewable:end -->
