### PR TITLE
[SPFarm]Fix: Regression Bug Databasename with a dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SPTrustedRootAuthority
   - Fixed issue where certificates not in the Personal store could not be used
+- Add-SPDscConfigDBLock
+  - Fixed issue where a Farm configuration Database could not contain a dash '-'
 
 ## [5.0.0] - 2021-12-17
 

--- a/SharePointDsc/Modules/SharePointDsc.Farm/SPFarm.psm1
+++ b/SharePointDsc/Modules/SharePointDsc.Farm/SPFarm.psm1
@@ -246,7 +246,7 @@ function Add-SPDscConfigDBLock
         $command.Connection = $connection
 
         # Added $Database just in case multiple farms are added at once.
-        $command.CommandText = "CREATE TABLE ##SPDscLock$Database (Locked BIT)"
+        $command.CommandText = "CREATE TABLE [##SPDscLock$Database] (Locked BIT)"
         $null = $command.ExecuteNonQuery()
     }
     finally


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes an regression bug with dashes '-' in configuration database names which made the helper function `Add-SPDscConfigDBLock` fail.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [X] Resource documentation added/updated in README.md. 
- [X] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [X] Comment-based help added/updated.
- [X] Localization strings added/updated in all localization files as appropriate.
- [X] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1380)
<!-- Reviewable:end -->
