### PR TITLE
SPUserProfileServiceApp: Fix issue where Get-TargetResource throws an error when no MySiteHost is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SPUserProfileServiceApp
+  - Fixed issue where error 'You cannot call a method on a null-valued expression' was thrown when no MySiteHost was specified
+
 ## [5.2.0] - 2022-05-12
 
 ### Added

--- a/SharePointDsc/DSCResources/MSFT_SPUserProfileServiceApp/MSFT_SPUserProfileServiceApp.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPUserProfileServiceApp/MSFT_SPUserProfileServiceApp.psm1
@@ -199,6 +199,7 @@ function Get-TargetResource
             $upMySiteLocation = $null
             $upMySiteManagedPath = $null
             $upSiteConflictNaming = $null
+            $mysiteHostLocation = $null
             try
             {
                 $ca = Get-SPWebApplication -IncludeCentralAdministration | Where-Object -FilterScript { $_.IsAdministrationWebApplication }
@@ -208,6 +209,10 @@ function Get-TargetResource
                 $upMySiteLocation = [System.Uri]$userProfileManager.MySiteHostUrl
                 $upMySiteManagedPath = $userProfileManager.PersonalSiteInclusion
                 $upSiteConflictNaming = $userProfileManager.PersonalSiteFormat
+                if (-not [string]::IsNullOrEmpty($upMySiteLocation.AbsoluteUri))
+                {
+                    $mysiteHostLocation = $upMySiteLocation.AbsoluteUri.TrimEnd('/')
+                }
             }
             catch
             {
@@ -223,7 +228,7 @@ function Get-TargetResource
                 Name                         = $serviceApp.DisplayName
                 ProxyName                    = $proxyName
                 ApplicationPool              = $serviceApp.ApplicationPool.Name
-                MySiteHostLocation           = $upMySiteLocation.AbsoluteUri.TrimEnd("/")
+                MySiteHostLocation           = $mysiteHostLocation
                 MySiteManagedPath            = $upMySiteManagedPath
                 ProfileDBName                = $databases.ProfileDatabase.Name
                 ProfileDBServer              = $databases.ProfileDatabase.NormalizedDataSource


### PR DESCRIPTION
#### Pull Request (PR) description

This PR Fixed issue where error 'You cannot call a method on a null-valued expression' was thrown when no MySiteHost was specified in the User Profile Service Application.

#### This Pull Request (PR) fixes the following issues

- Fixes #1306

#### Task list


- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/sharepointdsc/1412)
<!-- Reviewable:end -->
