### PR TITLE
SharePointDsc: Switch task that run HQRM tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 ### Changed
 
+- SharePointDsc
+  - The task `DscResource_Tests_Stop_On_Fail` that have ran HQRM tests will be removed in
+    the next version of Sampler and replaced by the task `Invoke_HQRM_Tests_Stop_On_Fail`.
 - SPFarm
   - Updated to run cmdlet `Update-SPFlightsConfigFile` on SharePoint Subscription.
 

--- a/build.yaml
+++ b/build.yaml
@@ -94,6 +94,7 @@ DscTest:
     - output
   ExcludeModuleFile:
     - Modules/DscResource.Common
+  MainGitBranch: master
 
 # Import ModuleBuilder tasks from a specific PowerShell module using the build
 # task's alias. Wildcard * can be used to specify all tasks that has a similar

--- a/build.yaml
+++ b/build.yaml
@@ -106,6 +106,8 @@ ModuleBuildTasks:
     - '*.ib.tasks'
   DscResource.DocGenerator:
     - 'Task.*'
+  DscResource.Test:
+    - 'Task.*'
 
 # Invoke-Build Header to be used to 'decorate' the terminal output of the tasks.
 TaskHeader: |

--- a/build.yaml
+++ b/build.yaml
@@ -42,7 +42,7 @@ BuildWorkflow:
     - package_module_nupkg
 
   hqrmtest:
-    - DscResource_Tests_Stop_On_Fail
+    - Invoke_HQRM_Tests_Stop_On_Fail
 
   # Defining test task to be run when invoking `./build.ps1 -Tasks test`
   test:


### PR DESCRIPTION
#### Pull Request (PR) description

- SharePointDsc
  - The task `DscResource_Tests_Stop_On_Fail` that have ran HQRM tests will be removed in
    the next version of Sampler and replaced by the task `Invoke_HQRM_Tests_Stop_On_Fail`.

#### This Pull Request (PR) fixes the following issues

Part of https://github.com/gaelcolas/Sampler/pull/428.

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1433)
<!-- Reviewable:end -->
