### PR TITLE
Fixes Compare-Object Exception if there are currently no CertificateN…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPFarm
   - Updated to run cmdlet `Update-SPFlightsConfigFile` on SharePoint Subscription.
 
+### Fixed
+
+- SPCertificateSettings
+  - Fixed an error where the command failed to add
+    SPCertificateNotificationContacts when there are currently none set.
+
 ## [5.4.0] - 2023-04-04
 
 ### Fixed

--- a/SharePointDsc/DSCResources/MSFT_SPCertificateSettings/MSFT_SPCertificateSettings.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPCertificateSettings/MSFT_SPCertificateSettings.psm1
@@ -319,119 +319,120 @@ function Set-TargetResource
             }
         }
     }
+}
 
-    function Test-TargetResource
-    {
-        [CmdletBinding()]
-        [OutputType([System.Boolean])]
-        param
-        (
-            [Parameter(Mandatory = $true)]
-            [ValidateSet('Yes')]
-            [System.String]
-            $IsSingleInstance,
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
 
-            [Parameter()]
-            [System.String]
-            $OrganizationalUnit,
+        [Parameter()]
+        [System.String]
+        $OrganizationalUnit,
 
-            [Parameter()]
-            [System.String]
-            $Organization,
+        [Parameter()]
+        [System.String]
+        $Organization,
 
-            [Parameter()]
-            [System.String]
-            $Locality,
+        [Parameter()]
+        [System.String]
+        $Locality,
 
-            [Parameter()]
-            [System.String]
-            $State,
+        [Parameter()]
+        [System.String]
+        $State,
 
-            [Parameter()]
-            [ValidateLength(2, 2)]
-            [System.String]
-            $Country,
+        [Parameter()]
+        [ValidateLength(2, 2)]
+        [System.String]
+        $Country,
 
-            [Parameter()]
-            [ValidateSet('ECC', 'RSA')]
-            [System.String]
-            $KeyAlgorithm,
+        [Parameter()]
+        [ValidateSet('ECC', 'RSA')]
+        [System.String]
+        $KeyAlgorithm,
 
-            [Parameter()]
-            [ValidateSet('0', '2048', '4096', '8192', '16384')]
-            [System.UInt16]
-            $KeySize,
+        [Parameter()]
+        [ValidateSet('0', '2048', '4096', '8192', '16384')]
+        [System.UInt16]
+        $KeySize,
 
-            [Parameter()]
-            [ValidateSet('nistP256', 'nistP384', 'nistP521')]
-            [System.String]
-            $EllipticCurve,
+        [Parameter()]
+        [ValidateSet('nistP256', 'nistP384', 'nistP521')]
+        [System.String]
+        $EllipticCurve,
 
-            [Parameter()]
-            [ValidateSet('SHA256', 'SHA384', 'SHA512')]
-            [System.String]
-            $HashAlgorithm,
+        [Parameter()]
+        [ValidateSet('SHA256', 'SHA384', 'SHA512')]
+        [System.String]
+        $HashAlgorithm,
 
-            [Parameter()]
-            [ValidateSet('Pkcs1', 'Pss')]
-            [System.String]
-            $RsaSignaturePadding,
+        [Parameter()]
+        [ValidateSet('Pkcs1', 'Pss')]
+        [System.String]
+        $RsaSignaturePadding,
 
-            [Parameter()]
-            [System.UInt32]
-            $CertificateExpirationAttentionThreshold,
+        [Parameter()]
+        [System.UInt32]
+        $CertificateExpirationAttentionThreshold,
 
-            [Parameter()]
-            [System.UInt32]
-            $CertificateExpirationWarningThreshold,
+        [Parameter()]
+        [System.UInt32]
+        $CertificateExpirationWarningThreshold,
 
-            [Parameter()]
-            [System.UInt32]
-            $CertificateExpirationErrorThreshold,
+        [Parameter()]
+        [System.UInt32]
+        $CertificateExpirationErrorThreshold,
 
-            [Parameter()]
-            [System.String[]]
-            $CertificateNotificationContacts
-        )
+        [Parameter()]
+        [System.String[]]
+        $CertificateNotificationContacts
+    )
 
-        Write-Verbose -Message "Testing certificate configuration settings"
+    Write-Verbose -Message "Testing certificate configuration settings"
 
-        $CurrentValues = Get-TargetResource @PSBoundParameters
+    $CurrentValues = Get-TargetResource @PSBoundParameters
 
-        Write-Verbose -Message "Current Values: $(Convert-SPDscHashtableToString -Hashtable $CurrentValues)"
-        Write-Verbose -Message "Target Values: $(Convert-SPDscHashtableToString -Hashtable $PSBoundParameters)"
+    Write-Verbose -Message "Current Values: $(Convert-SPDscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-SPDscHashtableToString -Hashtable $PSBoundParameters)"
 
-        $result = Test-SPDscParameterState -CurrentValues $CurrentValues `
-            -Source $($MyInvocation.MyCommand.Source) `
-            -DesiredValues $PSBoundParameters
+    $result = Test-SPDscParameterState -CurrentValues $CurrentValues `
+        -Source $($MyInvocation.MyCommand.Source) `
+        -DesiredValues $PSBoundParameters
 
-        Write-Verbose -Message "Test-TargetResource returned $result"
+    Write-Verbose -Message "Test-TargetResource returned $result"
 
-        return $result
-    }
+    return $result
+}
 
-    function Export-TargetResource
-    {
-        $VerbosePreference = "SilentlyContinue"
-        $ParentModuleBase = Get-Module "SharePointDsc" -ListAvailable | Select-Object -ExpandProperty Modulebase
-        $module = Join-Path -Path $ParentModuleBase -ChildPath  "\DSCResources\MSFT_SPCertificateSettings\MSFT_SPCertificateSettings.psm1" -Resolve
+function Export-TargetResource
+{
+    $VerbosePreference = "SilentlyContinue"
+    $ParentModuleBase = Get-Module "SharePointDsc" -ListAvailable | Select-Object -ExpandProperty Modulebase
+    $module = Join-Path -Path $ParentModuleBase -ChildPath  "\DSCResources\MSFT_SPCertificateSettings\MSFT_SPCertificateSettings.psm1" -Resolve
 
-        $Content = ''
-        $params = Get-DSCFakeParameters -ModulePath $module
-        $params.Country = "US"
+    $Content = ''
+    $params = Get-DSCFakeParameters -ModulePath $module
+    $params.Country = "US"
 
-        $PartialContent = "        SPCertificateSettings CertificateSettings`r`n"
-        $PartialContent += "        {`r`n"
-        $results = Get-TargetResource @params
-        $results = Repair-Credentials -results $results
-        $currentBlock = Get-DSCBlock -Params $results -ModulePath $module
-        $currentBlock = Convert-DSCStringParamToVariable -DSCBlock $currentBlock -ParameterName "PsDscRunAsCredential"
-        $PartialContent += $currentBlock
-        $PartialContent += "        }`r`n"
+    $PartialContent = "        SPCertificateSettings CertificateSettings`r`n"
+    $PartialContent += "        {`r`n"
+    $results = Get-TargetResource @params
+    $results = Repair-Credentials -results $results
+    $currentBlock = Get-DSCBlock -Params $results -ModulePath $module
+    $currentBlock = Convert-DSCStringParamToVariable -DSCBlock $currentBlock -ParameterName "PsDscRunAsCredential"
+    $PartialContent += $currentBlock
+    $PartialContent += "        }`r`n"
 
-        $Content += $PartialContent
+    $Content += $PartialContent
 
-        return $Content
-    }
+    return $Content
+}
 
-    Export-ModuleMember -Function *-TargetResource
+Export-ModuleMember -Function *-TargetResource

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPCertificateSettings.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPCertificateSettings.Tests.ps1
@@ -260,7 +260,7 @@ try
                                         CertificateExpirationWarningThresholdDays   = 15
                                         CertificateExpirationErrorThresholdDays     = 15
                                         CertificateNotificationContacts             = @(
-                                            @{
+                                            [PSCustomObject]@{
                                                 Address = 'wrong@contoso.com'
                                             }
                                         )
@@ -270,7 +270,7 @@ try
                                 Mock -CommandName Get-SPFarm -MockWith { return @{ } }
                                 Mock -CommandName Get-SPCertificateNotificationContact -MockWith {
                                     return @(
-                                        @{
+                                        [PSCustomObject]@{
                                             Address = 'wrong@contoso.com'
                                         }
                                     )

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPCertificateSettings.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPCertificateSettings.Tests.ps1
@@ -33,7 +33,7 @@ function Invoke-TestSetup
 
     $script:testEnvironment = Initialize-TestEnvironment `
         -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceFullName `
+        -DscResourceName $script:DSCResourceFullName `
         -ResourceType 'Mof' `
         -TestType 'Unit'
 }
@@ -282,6 +282,56 @@ try
                             It "Should return values from the get method" {
                                 $result = Get-TargetResource @testParams
                                 $result.CertificateNotificationContacts.Count | Should -Be 1
+                            }
+
+                            It "Should return false from the test method" {
+                                Test-TargetResource @testParams | Should -Be $false
+                            }
+
+                            It "Should update the certificate settings" {
+                                Set-TargetResource @testParams
+                                Assert-MockCalled Add-SPCertificateNotificationContact
+                                Assert-MockCalled Remove-SPCertificateNotificationContact
+                            }
+                        }
+
+                        Context -Name "The server is in a farm and zero contacts have been applied" -Fixture {
+                            BeforeAll {
+                                $testParams = @{
+                                    IsSingleInstance                = 'Yes'
+                                    CertificateNotificationContacts = 'admin@contoso.com'
+                                }
+
+                                Mock -CommandName Get-SPCertificateSettings -MockWith {
+                                    $returnVal = @{
+                                        DefaultOrganizationalUnit                   = ''
+                                        DefaultOrganization                         = ''
+                                        DefaultLocality                             = ''
+                                        DefaultState                                = ''
+                                        DefaultCountry                              = ''
+                                        DefaultKeyAlgorithm                         = 'RSA'
+                                        DefaultRsaKeySize                           = 2048
+                                        DefaultEllipticCurve                        = 'nistP256'
+                                        DefaultHashAlgorithm                        = 'SHA256'
+                                        DefaultRsaSignaturePadding                  = 'Pkcs1'
+                                        CertificateExpirationAttentionThresholdDays = 60
+                                        CertificateExpirationWarningThresholdDays   = 15
+                                        CertificateExpirationErrorThresholdDays     = 15
+                                        CertificateNotificationContacts             = [System.Net.Mail.MailAddressCollection]::new()
+                                    }
+                                    return $returnVal
+                                }
+                                Mock -CommandName Get-SPFarm -MockWith { return @{ } }
+                                Mock -CommandName Get-SPCertificateNotificationContact -MockWith {
+                                    return [System.Net.Mail.MailAddressCollection]::new()
+                                }
+                                Mock -CommandName Add-SPCertificateNotificationContact -MockWith {}
+                                Mock -CommandName Remove-SPCertificateNotificationContact -MockWith {}
+                            }
+
+                            It "Should return values from the get method" {
+                                $result = Get-TargetResource @testParams
+                                $result.CertificateNotificationContacts.Count | Should -Be 0
                             }
 
                             It "Should return false from the test method" {

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPCertificateSettings.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPCertificateSettings.Tests.ps1
@@ -341,7 +341,6 @@ try
                             It "Should update the certificate settings" {
                                 Set-TargetResource @testParams
                                 Assert-MockCalled Add-SPCertificateNotificationContact
-                                Assert-MockCalled Remove-SPCertificateNotificationContact
                             }
                         }
 


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project
    is greatly appreciated!

    Please prefix the PR title with the resource name, e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please keep the headers
    and the task list.
-->

#### Pull Request (PR) description

Fixes an Issue where the Ressource `Get-SPCertificateSettings` fails when setting SPCertificateNotificationContact and there are currently none set.

#### This Pull Request (PR) fixes the following issues

- Fixes #1430

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [X] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1437)
<!-- Reviewable:end -->
