### PR TITLE
SPSite: Fix: SPSite Constructur returns $null when run as Ressource on SPSE

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,6 +37,17 @@
         {
             "type": "PowerShell",
             "request": "launch",
+            "name": "Run current unit test (SPSE)",
+            "script": "${file}",
+            "args": [
+                "${workspaceRoot}/tests/Unit/Stubs/SharePoint/16.0.14326.20450/SharePointServer.psm1"
+            ],
+            "cwd": "${file}",
+            "createTemporaryIntegratedConsole": true
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
             "name": "Get current unit test code overage (SP2013)",
             "script": "${workspaceRoot}/.vscode/GetTestCoverage.ps1",
             "args": [
@@ -64,6 +75,17 @@
             "args": [
                 "${file}",
                 "${workspaceRoot}/Tests/Unit/Stubs/SharePoint/16.0.10337.12109/Microsoft.SharePoint.PowerShell.psm1"
+            ],
+            "createTemporaryIntegratedConsole": true
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "Get current unit test code overage (SPSE)",
+            "script": "${workspaceRoot}/.vscode/GetTestCoverage.ps1",
+            "args": [
+                "${file}",
+                "${workspaceRoot}/tests/Unit/Stubs/SharePoint/16.0.14326.20450/SharePointServer.psm1"
             ],
             "createTemporaryIntegratedConsole": true
         },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SPShellAdmins
   - Fixed that the Member comparison was not case insensitive.
+- SPSite
+  - The Get Method failed to get an existing Site Collection on SharePoint Server
+    Subscription Edition
+
 
 ## [5.5.0] - 2024-04-22
 

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPSite.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPSite.Tests.ps1
@@ -187,11 +187,11 @@ try
                     # Mock Get-SPSite for SPSSE on Get-TargetResource Call
                     if ($Global:SPDscHelper.CurrentStubBuildNumber.Build -gt 13000)
                     {
-                        $global:SPDscGetSPSiteCalled = 0
+                        $global:SPDscGetSPSiteCalledCount = 0
                         Mock -CommandName Get-SPSite -MockWith {
-                            if ($global:SPDscGetSPSiteCalled -lt 2)
+                            if ($global:SPDscGetSPSiteCalledCount -lt 4)
                             {
-                                ++$global:SPDscGetSPSiteCalled
+                                ++$global:SPDscGetSPSiteCalledCount
                                 return $null
                             }
                             else
@@ -372,8 +372,9 @@ try
             Context -Name "The site exists, but doesn't have default groups configured" -Fixture {
                 BeforeAll {
                     $testParams = @{
-                        Url        = "http://site.sharepoint.com"
-                        OwnerAlias = "DEMO\User"
+                        Url                 = "http://site.sharepoint.com"
+                        OwnerAlias          = "DEMO\User"
+                        CreateDefaultGroups = $true
                     }
 
                     Mock -CommandName Get-SPSite -MockWith {
@@ -398,7 +399,7 @@ try
                     (Get-TargetResource @testParams).CreateDefaultGroups | Should -Be $false
                 }
 
-                It "Should return true from the test method" {
+                It "Should return false from the test method" {
                     Test-TargetResource @testParams | Should -Be $false
                 }
 


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project
    is greatly appreciated!

    Please prefix the PR title with the resource name, e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please keep the headers
    and the task list.
-->

#### Pull Request (PR) description

The Get Method failed to get an existing Site Collection on SharePoint Server Subscription Edition

#### This Pull Request (PR) fixes the following issues

- Fixes #1442

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1443)
<!-- Reviewable:end -->
