### PR TITLE
SPSearchCrawlerImpactRule: Does throw if Rule does not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPShellAdmins
   - Fixed that the Member comparison was not case insensitive.
 
+- SPSearchCrawlerImpactRule
+  - Ressource threw an error if the Crawler Impact Rule did not exist when 
+    running the Get Method
+
 ## [5.5.0] - 2024-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed that the Member comparison was not case insensitive.
 
 - SPSearchCrawlerImpactRule
-  - Ressource threw an error if the Crawler Impact Rule did not exist when 
+  - Ressource threw an error if the Crawler Impact Rule did not exist when
     running the Get Method
 
 ## [5.5.0] - 2024-04-22

--- a/SharePointDsc/DSCResources/MSFT_SPSearchCrawlerImpactRule/MSFT_SPSearchCrawlerImpactRule.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPSearchCrawlerImpactRule/MSFT_SPSearchCrawlerImpactRule.psm1
@@ -60,7 +60,7 @@ function Get-TargetResource
         }
         else
         {
-            $crawlerImpactRule = Get-SPEnterpriseSearchSiteHitRule -Identity $params.Name -SearchService $params.ServiceAppName
+            $crawlerImpactRule = Get-SPEnterpriseSearchSiteHitRule -SearchService $params.ServiceAppName | Where-Object -FilterScript { $_.Site -eq $params.Name }
             if ($null -eq $crawlerImpactRule)
             {
                 return $nullReturn

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPSearchCrawlerImpactRule.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPSearchCrawlerImpactRule.Tests.ps1
@@ -32,7 +32,7 @@ function Invoke-TestSetup
 
     $script:testEnvironment = Initialize-TestEnvironment `
         -DSCModuleName $script:DSCModuleName `
-        -DSCResourceName $script:DSCResourceFullName `
+        -DscResourceName $script:DSCResourceFullName `
         -ResourceType 'Mof' `
         -TestType 'Unit'
 }
@@ -150,12 +150,12 @@ try
                         return [pscustomobject]@{
                             Site     = $testParams.Name
                             HitRate  = $testParams.RequestLimit
-                            Behavior = "SimultaneousRequests"
+                            Behavior = 0
                         }
                     }
                 }
 
-                It "Should return absent from the Get method" {
+                It "Should return Present from the Get method" {
                     (Get-TargetResource @testParams).Ensure | Should -Be "Present"
                 }
 
@@ -193,8 +193,8 @@ try
                     (Get-TargetResource @testParams).Ensure | Should -Be "Absent"
                 }
 
-                It "Should return false when the Test method is called" {
-                    Test-TargetResource @testParams | Should -Be $false
+                It "Should return true when the Test method is called" {
+                    Test-TargetResource @testParams | Should -Be $true
                 }
             }
 
@@ -330,7 +330,7 @@ try
                         return [pscustomobject]@{
                             Site     = $testParams.Name
                             HitRate  = $testParams.WaitTime
-                            Behavior = "DelayBetweenRequests"
+                            Behavior = 1
                         }
                     }
                 }

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPSearchCrawlerImpactRule.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPSearchCrawlerImpactRule.Tests.ps1
@@ -49,7 +49,7 @@ try
     InModuleScope -ModuleName $script:DSCResourceFullName -ScriptBlock {
         Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             BeforeAll {
-                Invoke-Command -ScriptBlock $Global:SPDscHelper.InitializeScript -NoNewScope
+                Invoke-Command -Scriptblock $Global:SPDscHelper.InitializeScript -NoNewScope
 
                 # Initialize tests
                 $getTypeFullName = "Microsoft.Office.Server.Search.Administration.SearchServiceApplication"
@@ -61,16 +61,16 @@ try
                 Mock -CommandName Get-SPServiceApplication -MockWith {
                     return @(
                         New-Object -TypeName "Object" |
-                        Add-Member -MemberType ScriptMethod `
-                            -Name GetType `
-                            -Value {
-                            New-Object -TypeName "Object" |
-                            Add-Member -MemberType NoteProperty `
-                                -Name FullName `
-                                -Value $getTypeFullName `
-                                -PassThru
-                        } `
-                            -PassThru -Force)
+                            Add-Member -MemberType ScriptMethod `
+                                -Name GetType `
+                                -Value {
+                                New-Object -TypeName "Object" |
+                                    Add-Member -MemberType NoteProperty `
+                                        -Name FullName `
+                                        -Value $getTypeFullName `
+                                        -PassThru
+                                } `
+                                    -PassThru -Force)
                 }
 
                 function Add-SPDscEvent
@@ -101,7 +101,7 @@ try
                 BeforeAll {
                     $testParams = @{
                         ServiceAppName = "Search Service Application"
-                        Name           = "http://site.sharepoint.com"
+                        Name           = "site.sharepoint.com"
                         RequestLimit   = 8
                         Ensure         = "Present"
                     }
@@ -135,7 +135,7 @@ try
                 BeforeAll {
                     $testParams = @{
                         ServiceAppName = "Search Service Application"
-                        Name           = "http://site.sharepoint.com"
+                        Name           = "site.sharepoint.com"
                         RequestLimit   = 8
                         Ensure         = "Present"
                     }
@@ -174,7 +174,7 @@ try
                 BeforeAll {
                     $testParams = @{
                         ServiceAppName = "Search Service Application"
-                        Name           = "http://site.sharepoint.com"
+                        Name           = "site.sharepoint.com"
                         Ensure         = "Absent"
                     }
 
@@ -211,7 +211,7 @@ try
                 BeforeAll {
                     $testParams = @{
                         ServiceAppName = "Search Service Application"
-                        Name           = "http://site.sharepoint.com"
+                        Name           = "site.sharepoint.com"
                         Ensure         = "Absent"
                     }
 
@@ -244,7 +244,7 @@ try
                 BeforeAll {
                     $testParams = @{
                         ServiceAppName = "Search Service Application"
-                        Name           = "http://site.sharepoint.com"
+                        Name           = "site.sharepoint.com"
                         Ensure         = "Absent"
                     }
 
@@ -271,7 +271,7 @@ try
                 BeforeAll {
                     $testParams = @{
                         ServiceAppName = "Search Service Application"
-                        Name           = "http://site.sharepoint.com"
+                        Name           = "site.sharepoint.com"
                         RequestLimit   = 8
                         WaitTime       = 60
                         Ensure         = "Present"
@@ -290,7 +290,7 @@ try
                 BeforeAll {
                     $testParams = @{
                         ServiceAppName = "Search Service Application"
-                        Name           = "http://site.sharepoint.com"
+                        Name           = "site.sharepoint.com"
                         WaitTime       = 300
                         Ensure         = "Present"
                     }
@@ -324,7 +324,7 @@ try
                 BeforeAll {
                     $testParams = @{
                         ServiceAppName = "Search Service Application"
-                        Name           = "http://site.sharepoint.com"
+                        Name           = "site.sharepoint.com"
                         WaitTime       = 300
                         Ensure         = "Present"
                     }

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPSearchCrawlerImpactRule.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPSearchCrawlerImpactRule.Tests.ps1
@@ -147,10 +147,10 @@ try
                     }
 
                     Mock -CommandName Get-SPEnterpriseSearchSiteHitRule -MockWith {
-                        return @{
-                            Name     = $testParams.Name
+                        return [pscustomobject]@{
+                            Site     = $testParams.Name
                             HitRate  = $testParams.RequestLimit
-                            Behavior = "0"
+                            Behavior = "SimultaneousRequests"
                         }
                     }
                 }
@@ -185,25 +185,16 @@ try
                     }
 
                     Mock -CommandName Get-SPEnterpriseSearchSiteHitRule -MockWith {
-                        return @{
-                            Name    = $testParams.Name
-                            HitRate = $testParams.RequestLimit
-                        }
+                        return $null
                     }
                 }
 
                 It "Should return present from the Get method" {
-                    (Get-TargetResource @testParams).Ensure | Should -Be "Present"
+                    (Get-TargetResource @testParams).Ensure | Should -Be "Absent"
                 }
 
                 It "Should return false when the Test method is called" {
                     Test-TargetResource @testParams | Should -Be $false
-                }
-
-                It "Should remove the search Site hit rule in the set method" {
-                    Set-TargetResource @testParams
-                    Assert-MockCalled Remove-SPEnterpriseSearchSiteHitRule
-
                 }
             }
 
@@ -336,26 +327,20 @@ try
                     }
 
                     Mock -CommandName Get-SPEnterpriseSearchSiteHitRule -MockWith {
-                        return @{
-                            Name     = $testParams.Name
+                        return [pscustomobject]@{
+                            Site     = $testParams.Name
                             HitRate  = $testParams.WaitTime
-                            Behavior = "1"
+                            Behavior = "DelayBetweenRequests"
                         }
                     }
                 }
 
-                It "Should return absent from the Get method" {
+                It "Should return Present from the Get method" {
                     (Get-TargetResource @testParams).Ensure | Should -Be "Present"
                 }
 
                 It "Should return true when the Test method is called" {
                     Test-TargetResource @testParams | Should -Be $true
-                }
-
-                It "Should update a new search Site hit rule in the set method" {
-                    Set-TargetResource @testParams
-                    Assert-MockCalled Remove-SPEnterpriseSearchSiteHitRule
-                    Assert-MockCalled New-SPEnterpriseSearchSiteHitRule
                 }
             }
         }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project
    is greatly appreciated!

    Please prefix the PR title with the resource name, e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please keep the headers
    and the task list.
-->

#### Pull Request (PR) description

The Ressource threw an error if the Crawler Impact Rule did not exist. 

#### This Pull Request (PR) fixes the following issues

- Fixes #1444

#### Task list

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1445)
<!-- Reviewable:end -->
