### PR TITLE
SPInstallPrereqs: Handle ExitCode -1 (download of a package failed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SPInstallPrereqs
+  - Trigger a machine reboot when the installer returns error -1 (download of a package failed), to allow a retry.
+
 ## [5.7.0] - 2025-10-22
 
 ### Fixed
@@ -12,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SPDistributedCacheClientSettings
   - Resource threw an error on SharePoint Server Subscription Edition with Build >= 16.0.18526.20080.
 - SPInstallPrereqs
-  - Trigger a machine reboot when the installer returns the generic error 0x80004005, to allow a retry
+  - Trigger a machine reboot when the installer returns the generic error 0x80004005, to allow a retry.
   - Added Fix for SharePoint Desired State Configuration test for SharePoint SPSE on prerequisite MSVCRT142.
 
 ### Changed

--- a/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -1202,6 +1202,18 @@ function Set-TargetResource
                     "to reboot the machine before continuing.")
             $global:DSCMachineStatus = 1
         }
+        -1
+        {
+            # ExitCode -1 is when download of a package failed (frequent transient issue in Azure)
+            $message = ("The prerequisite installer has failed with error -1, " + `
+                    "(download of a package failed), do a reboot and retry.")
+            Write-Verbose -Message $message
+            Add-SPDscEvent -Message $message `
+                -EntryType 'Error' `
+                -EventID 100 `
+                -Source $MyInvocation.MyCommand.Source
+            $global:DSCMachineStatus = 1
+        }
         -2147467259
         {
             # This is the generic error 0x80004005, that should be fixed with a reboot
@@ -1483,7 +1495,7 @@ function Test-SPDscPrereqInstallStatus
                     }
                 }
             }
-            Default
+            default
             {
                 $message = ("Unable to search for a prereq with mode '$($itemToCheck.SearchType)'. " + `
                         "please use either 'Equals', 'Like' or 'Match', or 'BundleUpgradeCode'")

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
@@ -227,8 +227,6 @@ try
                     $global:DSCMachineStatus = 0
 
                     Set-TargetResource @testParams
-                    Should -Invoke -CommandName Start-Process -Exactly -Times 1 -Scope It
-                    Should -Invoke -CommandName Add-SPDscEvent -Scope It
                     $global:DSCMachineStatus | Should -Be 1
                 }
 
@@ -238,8 +236,6 @@ try
                     $global:DSCMachineStatus = 0
 
                     Set-TargetResource @testParams
-                    Should -Invoke -CommandName Start-Process -Exactly -Times 1 -Scope It
-                    Should -Invoke -CommandName Add-SPDscEvent -Scope It
                     $global:DSCMachineStatus | Should -Be 1
                 }
 

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
@@ -216,9 +216,11 @@ try
 
                 It "Should call the prerequisite installer from the set method and records the need for a reboot" {
                     Mock -CommandName Start-Process { return @{ ExitCode = 3010 } }
+                    $global:DSCMachineStatus = 0
 
                     Set-TargetResource @testParams
                     Assert-MockCalled Start-Process
+                    $global:DSCMachineStatus | Should -Be 1
                 }
 
                 It "Should call the prerequisite installer from the set method, record error -1 and trigger a reboot for a retry" {
@@ -227,6 +229,8 @@ try
                     $global:DSCMachineStatus = 0
 
                     Set-TargetResource @testParams
+                    Assert-MockCalled Start-Process
+                    Assert-MockCalled Add-SPDscEvent
                     $global:DSCMachineStatus | Should -Be 1
                 }
 
@@ -236,6 +240,8 @@ try
                     $global:DSCMachineStatus = 0
 
                     Set-TargetResource @testParams
+                    Assert-MockCalled Start-Process
+                    Assert-MockCalled Add-SPDscEvent
                     $global:DSCMachineStatus | Should -Be 1
                 }
 

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
@@ -49,7 +49,7 @@ try
     InModuleScope -ModuleName $script:DSCResourceFullName -ScriptBlock {
         Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             BeforeAll {
-                Invoke-Command -ScriptBlock $Global:SPDscHelper.InitializeScript -NoNewScope
+                Invoke-Command -Scriptblock $Global:SPDscHelper.InitializeScript -NoNewScope
 
                 # Initialize tests
                 function New-SPDscMockPrereq
@@ -225,14 +225,16 @@ try
                     Mock -CommandName Start-Process { return @{ ExitCode = -1 } }
 
                     Set-TargetResource @testParams
-                    Assert-MockCalled Start-Process
+                    Should -Invoke -CommandName Start-Process -Exactly -Times 1 -Scope It
+                    $global:DSCMachineStatus | Should -Be 1
                 }
 
                 It "Should call the prerequisite installer from the set method, record an error and trigger a reboot for a retry" {
                     Mock -CommandName Start-Process { return @{ ExitCode = -2147467259 } }
 
                     Set-TargetResource @testParams
-                    Assert-MockCalled Start-Process
+                    Should -Invoke -CommandName Start-Process -Exactly -Times 1 -Scope It
+                    $global:DSCMachineStatus | Should -Be 1
                 }
 
                 It "Should call the prerequisite installer from the set method and a pending reboot is preventing it from running" {
@@ -259,12 +261,6 @@ try
                     Mock -CommandName Start-Process { return @{ ExitCode = 2 } }
 
                     { Set-TargetResource @testParams } | Should -Throw "Invalid command line parameters"
-                }
-
-                It "Should call the prerequisite installer from the set method and throws for unknown error codes" {
-                    Mock -CommandName Start-Process { return @{ ExitCode = -1 } }
-
-                    { Set-TargetResource @testParams } | Should -Throw "unknown exit code"
                 }
             }
 

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
@@ -223,17 +223,23 @@ try
 
                 It "Should call the prerequisite installer from the set method, record error -1 and trigger a reboot for a retry" {
                     Mock -CommandName Start-Process { return @{ ExitCode = -1 } }
+                    Mock -CommandName Add-SPDscEvent { }
+                    $global:DSCMachineStatus = 0
 
                     Set-TargetResource @testParams
                     Should -Invoke -CommandName Start-Process -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Add-SPDscEvent -Scope It
                     $global:DSCMachineStatus | Should -Be 1
                 }
 
                 It "Should call the prerequisite installer from the set method, record error -2147467259 and trigger a reboot for a retry" {
                     Mock -CommandName Start-Process { return @{ ExitCode = -2147467259 } }
+                    Mock -CommandName Add-SPDscEvent { }
+                    $global:DSCMachineStatus = 0
 
                     Set-TargetResource @testParams
                     Should -Invoke -CommandName Start-Process -Exactly -Times 1 -Scope It
+                    Should -Invoke -CommandName Add-SPDscEvent -Scope It
                     $global:DSCMachineStatus | Should -Be 1
                 }
 

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
@@ -49,7 +49,7 @@ try
     InModuleScope -ModuleName $script:DSCResourceFullName -ScriptBlock {
         Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             BeforeAll {
-                Invoke-Command -Scriptblock $Global:SPDscHelper.InitializeScript -NoNewScope
+                Invoke-Command -ScriptBlock $Global:SPDscHelper.InitializeScript -NoNewScope
 
                 # Initialize tests
                 function New-SPDscMockPrereq
@@ -222,6 +222,13 @@ try
                 }
 
                 It "Should call the prerequisite installer from the set method, record an error and trigger a reboot for a retry" {
+                    Mock -CommandName Start-Process { return @{ ExitCode = -1 } }
+
+                    Set-TargetResource @testParams
+                    Assert-MockCalled Start-Process
+                }
+
+                It "Should call the prerequisite installer from the set method, record an error and trigger a reboot for a retry" {
                     Mock -CommandName Start-Process { return @{ ExitCode = -2147467259 } }
 
                     Set-TargetResource @testParams
@@ -342,7 +349,7 @@ try
                                 }
                             }
                         }
-                        Default
+                        default
                         {
                             throw [Exception] "A supported version of SharePoint was not used in testing"
                         }
@@ -565,7 +572,7 @@ try
                                 $requiredParams = @("DotNet48", "MSVCRT142")
                             }
                         }
-                        Default
+                        default
                         {
                             throw [Exception] "A supported version of SharePoint was not used in testing"
                         }
@@ -635,7 +642,7 @@ try
                                 $requiredParams = @("DotNet48", "MSVCRT142")
                             }
                         }
-                        Default
+                        default
                         {
                             throw [Exception] "A supported version of SharePoint was not used in testing"
                         }
@@ -705,7 +712,7 @@ try
                                 $requiredParams = @("DotNet48", "MSVCRT142")
                             }
                         }
-                        Default
+                        default
                         {
                             throw [Exception] "A supported version of SharePoint was not used in testing"
                         }
@@ -768,7 +775,7 @@ try
                         {
                             $requiredParams = @("SQLNCli", "Sync", "AppFabric", "IDFX11", "MSIPCClient", "KB3092423", "WCFDataServices56", "DotNetFx", "MSVCRT11", "MSVCRT14", "ODBC")
                         }
-                        Default
+                        default
                         {
                             throw [Exception] "A supported version of SharePoint was not used in testing"
                         }
@@ -909,7 +916,7 @@ try
                         {
                             $requiredParams = @("SQLNCli", "Sync", "AppFabric", "IDFX11", "MSIPCClient", "KB3092423", "WCFDataServices56", "DotNetFx", "MSVCRT11", "MSVCRT14", "ODBC")
                         }
-                        Default
+                        default
                         {
                             throw [Exception] "A supported version of SharePoint was not used in testing"
                         }

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
@@ -221,7 +221,7 @@ try
                     Assert-MockCalled Start-Process
                 }
 
-                It "Should call the prerequisite installer from the set method, record an error and trigger a reboot for a retry" {
+                It "Should call the prerequisite installer from the set method, record error -1 and trigger a reboot for a retry" {
                     Mock -CommandName Start-Process { return @{ ExitCode = -1 } }
 
                     Set-TargetResource @testParams
@@ -229,7 +229,7 @@ try
                     $global:DSCMachineStatus | Should -Be 1
                 }
 
-                It "Should call the prerequisite installer from the set method, record an error and trigger a reboot for a retry" {
+                It "Should call the prerequisite installer from the set method, record error -2147467259 and trigger a reboot for a retry" {
                     Mock -CommandName Start-Process { return @{ ExitCode = -2147467259 } }
 
                     Set-TargetResource @testParams


### PR DESCRIPTION
#### Pull Request (PR) description

SPInstallPrereqs: Trigger a machine reboot when the installer returns error -1 (download of a package failed), to allow a retry.

#### This Pull Request (PR) fixes the following issues

This prevents the unexpected termination of DSC when a transient network issue prevents the installer to download a package (frequent in Azure), by triggering a reboot to redo the download.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1472)
<!-- Reviewable:end -->
