### PR TITLE
Avoid random error with Write-EventLog in Windows Server 2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SPInstallPrereqs
   - Trigger a machine reboot when the installer returns error -1 (download of a package failed), to allow a retry.
+- SharePointDsc
+  - Prevent random error "The registry key for the log "SPDsc" for source "MSFT_SPFarm" could not be opened" when
+    running cmdlet `Write-EventLog` in function `Add-SPDscEvent`. It happens randomly in Windows Server 2025
 
 ## [5.7.0] - 2025-10-22
 

--- a/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
+++ b/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
@@ -48,7 +48,7 @@ function Add-SPDscEvent
     try
     {
         Write-EventLog -LogName $LogName -Source $Source `
-            -EventId $EventID -Message $Message -EntryType $EntryType -ErrorAction SilentlyContinue
+            -EventId $EventID -Message $Message -EntryType $EntryType -ErrorAction Stop
     }
     catch
     {

--- a/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
+++ b/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
@@ -48,7 +48,7 @@ function Add-SPDscEvent
     try
     {
         Write-EventLog -LogName $LogName -Source $Source `
-            -EventId $EventID -Message $Message -EntryType $EntryType
+            -EventId $EventID -Message $Message -EntryType $EntryType -ErrorAction SilentlyContinue
     }
     catch
     {


### PR DESCRIPTION
#### Pull Request (PR) description

Randomly (about 15-20%), deployments fail in Windows Server 2025 because of error "The registry key for the log "SPDsc" for source "MSFT_SPFarm" could not be opened", when running cmdlet `Write-EventLog` in function `Add-SPDscEvent`.

Please note:
- This error is not easy to repro, it works fine most of the time, but somehow it happens from time to time with Windows Server 2025
- This change is totally safe, since it only complements the existing try/catch (which does not trap cmdlet errors). Beside, if the logging fails, we really do not want this to interrupt the deployment.

#### This Pull Request (PR) fixes the following issues

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1473)
<!-- Reviewable:end -->
