### PR TITLE
SPSite: Fix Get returning null site properties on SPSE when run by the LCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SPSite
+  - Fixed the Get method returning null Owner and RootWeb properties (OwnerAlias, Name,
+    Template) on SharePoint Server Subscription Edition when run by the LCM, which caused a
+    permanent drift. The site is now re-opened with the Central Admin system account token
+    when the Owner is missing.
+
 ## [5.7.1] - 2026-06-08
 
 ### Fixed
@@ -13,11 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Trigger a machine reboot when the installer returns error -1 (download of a package failed), to allow a retry.
 - SPProjectServerLicense
   - Update the regex to correctly detect Project Server Subscription Edition.
-- SPSite
-  - Fixed the Get method returning null Owner and RootWeb properties (OwnerAlias, Name,
-    Template) on SharePoint Server Subscription Edition when run by the LCM, which caused a
-    permanent drift. The site is now re-opened with the Central Admin system account token
-    when the Owner is missing.
 - SharePointDsc
   - Prevent random error "The registry key for the log "SPDsc" for source "MSFT_SPFarm" could not be opened" when
     running cmdlet `Write-EventLog` in function `Add-SPDscEvent`. It happens randomly in Windows Server 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Trigger a machine reboot when the installer returns error -1 (download of a package failed), to allow a retry.
 - SPProjectServerLicense
   - Update the regex to correctly detect Project Server Subscription Edition.
+- SPSite
+  - Fixed the Get method returning null Owner and RootWeb properties (OwnerAlias, Name,
+    Template) on SharePoint Server Subscription Edition when run by the LCM, which caused a
+    permanent drift. The site is now re-opened with the Central Admin system account token
+    when the Owner is missing.
 - SharePointDsc
   - Prevent random error "The registry key for the log "SPDsc" for source "MSFT_SPFarm" could not be opened" when
     running cmdlet `Write-EventLog` in function `Add-SPDscEvent`. It happens randomly in Windows Server 2025

--- a/SharePointDsc/DSCResources/MSFT_SPSite/MSFT_SPSite.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPSite/MSFT_SPSite.psm1
@@ -77,9 +77,35 @@ function Get-TargetResource
         if ($productVersion.FileMajorPart -eq 16 `
                 -and $productVersion.FileBuildPart -gt 13000)
         {
-            # On SharePoint Subscription Edition the Microsoft.SharePoint.SPSite Constructor never gets a Site Collection when run by the LCM.
-            # Fixes 1442: https://github.com/dsccommunity/SharePointDsc/issues/1442
+            # On SharePoint Subscription Edition the Microsoft.SharePoint.SPSite constructor by URL
+            # returns no site when run by the LCM, so retrieve the site with Get-SPSite (Fixes 1442).
+            # In that context the Owner and RootWeb properties of the returned site can come back
+            # $null (for example for a host-named site collection), which produces a permanent drift.
+            # When the Owner is missing, re-open the site with the Central Admin system account token
+            # using the site Id - the same pattern Set-TargetResource uses - so the properties are
+            # read reliably (Fixes 1453).
             $site = Get-SPSite -Identity $params.Url -ErrorAction SilentlyContinue
+
+            if ($null -ne $site -and $null -eq $site.Owner)
+            {
+                try
+                {
+                    $centralAdminWebApp = [Microsoft.SharePoint.Administration.SPAdministrationWebApplication]::Local
+                    $centralAdminSite = Get-SPSite -Identity $centralAdminWebApp.Url -ErrorAction Stop
+
+                    $siteAsSystem = New-Object "Microsoft.SharePoint.SPSite" `
+                        -ArgumentList @($site.Id, $centralAdminSite.SystemAccount.UserToken)
+
+                    if ($null -ne $siteAsSystem)
+                    {
+                        $site = $siteAsSystem
+                    }
+                }
+                catch [System.Exception]
+                {
+                    # Keep the site returned by Get-SPSite when the system-account re-open fails.
+                }
+            }
         }
         else
         {

--- a/SharePointDsc/DSCResources/MSFT_SPSite/MSFT_SPSite.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPSite/MSFT_SPSite.psm1
@@ -104,6 +104,9 @@ function Get-TargetResource
                 catch [System.Exception]
                 {
                     # Keep the site returned by Get-SPSite when the system-account re-open fails.
+                    Write-Verbose -Message ("Could not re-open site '$($params.Url)' with the " + `
+                            "Central Admin system account token; using the site returned by " + `
+                            "Get-SPSite. Error: $($_.Exception.Message)")
                 }
             }
         }

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPSite.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPSite.Tests.ps1
@@ -369,6 +369,84 @@ try
                 }
             }
 
+            Context -Name "The site exists but returns no owner when retrieved on SharePoint Subscription Edition" -Fixture {
+                BeforeAll {
+                    $testParams = @{
+                        Url        = "http://site.sharepoint.com"
+                        OwnerAlias = "DEMO\owner"
+                    }
+
+                    # On SharePoint Subscription Edition, Get-SPSite retrieves the site (fix for
+                    # issue #1442) but its Owner and RootWeb properties come back null when run by
+                    # the LCM (issue #1453). Reproduce that by returning a site without an owner.
+                    Mock -CommandName Get-SPSite -MockWith {
+                        return @{
+                            Id                     = "11111111-1111-1111-1111-111111111111"
+                            HostHeaderIsSiteName   = $true
+                            WebApplication         = @{
+                                Url                     = $testParams.Url
+                                UseClaimsAuthentication = $false
+                            }
+                            Url                    = $testParams.Url
+                            Owner                  = $null
+                            SecondaryContact       = $null
+                            Quota                  = @{ QuotaId = 0 }
+                            RootWeb                = @{
+                                AssociatedVisitorGroup = "Visitors"
+                                AssociatedMemberGroup  = "Members"
+                                AssociatedOwnerGroup   = "Owners"
+                                Name                   = $null
+                                WebTemplate            = $null
+                                Configuration          = $null
+                            }
+                            AdministrationSiteType = "None"
+                        }
+                    } -ParameterFilter { $Identity -eq $testParams.Url }
+
+                    # Re-opening the site with the Central Admin system account token returns the
+                    # fully populated site, so the properties can be read reliably.
+                    Mock -CommandName New-Object -MockWith {
+                        $site = @{
+                            Id                     = "11111111-1111-1111-1111-111111111111"
+                            HostHeaderIsSiteName   = $true
+                            WebApplication         = @{
+                                Url                     = $testParams.Url
+                                UseClaimsAuthentication = $false
+                            }
+                            Url                    = $testParams.Url
+                            Owner                  = @{ UserLogin = "DEMO\owner"; Email = "owner@contoso.com" }
+                            SecondaryContact       = $null
+                            Quota                  = @{ QuotaId = 0 }
+                            RootWeb                = @{
+                                AssociatedVisitorGroup = "Visitors"
+                                AssociatedMemberGroup  = "Members"
+                                AssociatedOwnerGroup   = "Owners"
+                                Name                   = "TeamSite"
+                                WebTemplate            = "STS"
+                                Configuration          = 0
+                            }
+                            AdministrationSiteType = "None"
+                        }
+                        $Script:SPDscSystemAccountSite = $site
+                        return $site
+                    } -ParameterFilter {
+                        $TypeName -eq "Microsoft.SharePoint.SPSite" -and
+                        $ArgumentList[1] -eq "CentralAdminSystemAccountUserToken"
+                    }
+                }
+
+                It "Should read the owner and template from the get method" {
+                    $result = Get-TargetResource @testParams
+                    $result.OwnerAlias | Should -Be "DEMO\owner"
+                    $result.Template | Should -Be "STS#0"
+                    $result.Name | Should -Be "TeamSite"
+                }
+
+                It "Should return true from the test method" {
+                    Test-TargetResource @testParams | Should -Be $true
+                }
+            }
+
             Context -Name "The site exists, but doesn't have default groups configured" -Fixture {
                 BeforeAll {
                     $testParams = @{


### PR DESCRIPTION
#### Pull Request (PR) description

On SharePoint Server Subscription Edition (build > 13000) `Get-TargetResource` retrieves the site with `Get-SPSite -Identity` (fix for #1442, because the `Microsoft.SharePoint.SPSite` constructor by URL returns no site under the LCM). In that context the Owner and RootWeb properties (OwnerAlias, Name, Template, associated groups) of the returned site can come back `$null` (for example for a host-named site collection), which produces a permanent, cosmetic drift.

When the Owner is missing, the site is now re-opened with the Central Admin system account token using the site Id — the same pattern `Set-TargetResource` already uses — so the properties are read reliably. The nominal path (Owner present) is unchanged, so existing behaviour is preserved.

Validated on a live SharePoint Server Subscription Edition farm: the SPSite resource is back InDesiredState (no more OwnerAlias drift) after the fix.

#### This Pull Request (PR) fixes the following issues

- Fixes #1453

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1477)
<!-- Reviewable:end -->
