### PR TITLE
SPSite: Fix Get returning an empty Name by reading the RootWeb Title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Template) on SharePoint Server Subscription Edition when run by the LCM, which caused a
     permanent drift. The site is now re-opened with the Central Admin system account token
     when the Owner is missing.
+  - Fixed the Get method returning an empty Name because it read the RootWeb Name property
+    (always empty on an SPWeb) instead of the Title. The site collection name is now read
+    from the RootWeb Title, resolved through the multilingual TitleResource when available.
 
 ## [5.7.1] - 2026-06-08
 

--- a/SharePointDsc/DSCResources/MSFT_SPSite/MSFT_SPSite.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPSite/MSFT_SPSite.psm1
@@ -211,6 +211,19 @@ function Get-TargetResource
                 $CreateDefaultGroups = $false
             }
 
+            # The RootWeb Name property is empty on an SPWeb object; the site collection name is
+            # held in the Title property. Use the multilingual TitleResource for the web's UI
+            # culture when available, falling back to the plain Title.
+            $rootWebName = $site.RootWeb.Title
+            try
+            {
+                $rootWebName = $site.RootWeb.TitleResource.GetValueForUICulture($site.RootWeb.UICulture)
+            }
+            catch
+            {
+                # Fall back to the plain Title when TitleResource / UICulture is unavailable.
+            }
+
             return @{
                 Url                      = $site.Url
                 OwnerAlias               = $owner
@@ -219,7 +232,7 @@ function Get-TargetResource
                 Description              = $site.RootWeb.Description
                 HostHeaderWebApplication = $HostHeaderWebApplication
                 Language                 = $site.RootWeb.Language
-                Name                     = $site.RootWeb.Name
+                Name                     = $rootWebName
                 OwnerEmail               = $site.Owner.Email
                 QuotaTemplate            = $quota
                 SecondaryEmail           = $site.SecondaryContact.Email

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPSite.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPSite.Tests.ps1
@@ -422,6 +422,7 @@ try
                                 AssociatedMemberGroup  = "Members"
                                 AssociatedOwnerGroup   = "Owners"
                                 Name                   = "TeamSite"
+                                Title                  = "TeamSite"
                                 WebTemplate            = "STS"
                                 Configuration          = 0
                             }
@@ -444,6 +445,57 @@ try
 
                 It "Should return true from the test method" {
                     Test-TargetResource @testParams | Should -Be $true
+                }
+            }
+
+            Context -Name "The site exists and its RootWeb name comes from the Title property" -Fixture {
+                BeforeAll {
+                    $testParams = @{
+                        Url        = "http://site.sharepoint.com"
+                        OwnerAlias = "DEMO\owner"
+                    }
+
+                    # The RootWeb Name property is empty on an SPWeb object; the site collection
+                    # name is held in the Title property (issue #1441). The get method must return
+                    # the Title, resolved through the multilingual TitleResource when available.
+                    $contextSiteImplementation = {
+                        $site = $siteImplementation.InvokeReturnAsIs()
+                        $site.WebApplication.Url = $testParams.Url
+                        $site.WebApplication.UseClaimsAuthentication = $false
+                        $site.Url = $testParams.Url
+                        $site.Owner = @{ UserLogin = "DEMO\owner" }
+                        $site.RootWeb.AssociatedVisitorGroup = "Visitors"
+                        $site.RootWeb.AssociatedMemberGroup = "Members"
+                        $site.RootWeb.AssociatedOwnerGroup = "Owners"
+                        $site.RootWeb.Name = ""
+                        $site.RootWeb.Title = "My Fancy Title"
+                        $site.RootWeb.UICulture = 1033
+                        $titleResource = @{ }
+                        $titleResource = $titleResource | Add-Member -MemberType ScriptMethod `
+                            -Name GetValueForUICulture -Value { return "My Fancy Title" } -PassThru
+                        $site.RootWeb.TitleResource = $titleResource
+                        return $site
+                    }
+
+                    Mock -CommandName New-Object -MockWith {
+                        $site = $contextSiteImplementation.InvokeReturnAsIs()
+                        $Script:SPDscSystemAccountSite = $site
+                        return $site
+                    } -ParameterFilter {
+                        $TypeName -eq "Microsoft.SharePoint.SPSite" -and
+                        $ArgumentList[0] -eq $testParams.Url -and
+                        $ArgumentList[1] -eq "CentralAdminSystemAccountUserToken"
+                    }
+
+                    Mock -CommandName Get-SPSite -MockWith {
+                        $site = $contextSiteImplementation.InvokeReturnAsIs()
+                        $Script:SPDscSite = $site
+                        return $site
+                    }
+                }
+
+                It "Should return the RootWeb Title as the Name from the get method" {
+                    (Get-TargetResource @testParams).Name | Should -Be "My Fancy Title"
                 }
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description

`Get-TargetResource` returned an empty `Name` because it read `$site.RootWeb.Name`, which is always empty on an `SPWeb` object. The site collection name is held in the `Title` property. The name is now read from the RootWeb `Title`, resolved through the multilingual `TitleResource` for the web's UI culture when available and falling back to the plain `Title`. This matches how `Export-TargetResource` already reads the site title.

Validated on a live SharePoint Server Subscription Edition farm: for a site collection where `RootWeb.Name` is empty, `RootWeb.Title` (and `TitleResource.GetValueForUICulture`) correctly return the site name.

#### This Pull Request (PR) fixes the following issues

- Fixes #1441

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1478)
<!-- Reviewable:end -->
