### PR TITLE
CODEOWNERS: Request reviews from the sharepointdsc team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
+# cSpell: ignore sharepointdsc
+# Each line is a file pattern followed by one or more owners.
+
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-*       @ykuijs
+# @dsccommunity/sharepointdsc will be requested for review when
+# someone opens a pull request.
+* @dsccommunity/sharepointdsc
+/* @ykuijs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CODEOWNERS
+  - Request reviews from the @dsccommunity/sharepointdsc team, with @ykuijs as the default
+    owner, aligning the file with the other DSC Community repositories.
+
 ## [5.7.1] - 2026-06-08
 
 ### Fixed


### PR DESCRIPTION
#### Pull Request (PR) description

Replaces the placeholder `CODEOWNERS` file with the DSC Community convention used by the other repositories (e.g. SqlServerDsc): the `@dsccommunity/sharepointdsc` team becomes the default reviewer for the repository, and `@ykuijs` remains the root owner.

#### This Pull Request (PR) fixes the following issues

- Fixes #1461

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1479)
<!-- Reviewable:end -->
