### PR TITLE
SPDistributedCacheService: Fix domain doubled when server name is already an FQDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed the domain being appended a second time when a server name in ServerProvisionOrder
     is already a fully qualified domain name (FQDN). The doubled domain (server.domain.domain)
     prevented the distributed cache from starting. The domain is now only added when the
-    server name is not already an FQDN.
+    server name is not already an FQDN (#1468).
 
 ## [5.7.1] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed the Get method returning an empty Name because it read the RootWeb Name property
     (always empty on an SPWeb) instead of the Title. The site collection name is now read
     from the RootWeb Title, resolved through the multilingual TitleResource when available.
+- SPDistributedCacheService
+  - Fixed the domain being appended a second time when a server name in ServerProvisionOrder
+    is already a fully qualified domain name (FQDN). The doubled domain (server.domain.domain)
+    prevented the distributed cache from starting. The domain is now only added when the
+    server name is not already an FQDN.
 
 ## [5.7.1] - 2026-06-08
 

--- a/SharePointDsc/DSCResources/MSFT_SPDistributedCacheService/MSFT_SPDistributedCacheService.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPDistributedCacheService/MSFT_SPDistributedCacheService.psm1
@@ -205,7 +205,10 @@ function Set-TargetResource
                         if ($null -eq $si)
                         {
                             $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
-                            $currentServer = "$currentServer.$domain"
+                            if ($currentServer -notlike "*.$domain")
+                            {
+                                $currentServer = "$currentServer.$domain"
+                            }
                         }
 
                         Write-Verbose "Waiting for cache on $currentServer"

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPDistributedCacheService.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPDistributedCacheService.Tests.ps1
@@ -371,6 +371,42 @@ try
                 }
             }
 
+            Context -Name "Distributed cache is not configured, ServerProvisionOrder specified with an FQDN server name" -Fixture {
+                BeforeAll {
+                    $testParams = @{
+                        Name                 = "AppFabricCache"
+                        Ensure               = "Present"
+                        CacheSizeInMB        = 1024
+                        ServiceAccount       = "DOMAIN\user"
+                        ServerProvisionOrder = "Server1.contoso.com", $env:COMPUTERNAME
+                        CreateFirewallRules  = $true
+                    }
+
+                    Mock -CommandName Start-Sleep -MockWith { }
+
+                    Mock -CommandName Get-CimInstance -MockWith {
+                        return @{
+                            Domain = "contoso.com"
+                        }
+                    }
+                    Mock -CommandName Use-CacheCluster -MockWith {
+                        throw [Exception] "ERRPS001 Error in reading provider and connection string values."
+                    }
+                    $Global:SPDscDCacheOnline = $false
+
+                    # Returns no distributed cache instance for the FQDN name, forcing the
+                    # code path that appends the domain to the server name.
+                    Mock -CommandName Get-SPServiceInstance -MockWith {
+                        return @()
+                    } -ParameterFilter { $Server -eq "Server1.contoso.com" }
+                }
+
+                It "Should not append the domain again when the server name is already an FQDN" {
+                    Set-TargetResource @testParams
+                    Assert-MockCalled Get-SPServiceInstance -ParameterFilter { $Server -eq "Server1.contoso.com.contoso.com" } -Times 0 -Exactly
+                }
+            }
+
             Context -Name "Distributed cache is not configured, ServerProvisionOrder specified" -Fixture {
                 BeforeAll {
                     $testParams = @{


### PR DESCRIPTION
## Pull Request (PR) description

When `ServerProvisionOrder` contains a server name that is already a fully qualified
domain name (FQDN), `Set-TargetResource` unconditionally appended the domain a second
time (`$currentServer = "$currentServer.$domain"`), producing `server.domain.domain`.
`Get-SPServiceInstance` never matched that doubled name, so the distributed cache
service instance was never found and the cache failed to start.

The domain is now only appended when the server name is not already an FQDN
(`if ($currentServer -notlike "*.$domain")`).

Validated live on a real SharePoint Server Subscription Edition farm where SharePoint
stores the DC instance under the short name. With an FQDN entry in `ServerProvisionOrder`:
- Before: the code queried `WFE1.<domain>.<domain>` (doubled) → DC never found.
- After:  the code queries `WFE1.<domain>` → correct.

## This Pull Request (PR) fixes the following issues

Fixes #1468

## Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1480)
<!-- Reviewable:end -->
