### PR TITLE
SPInstallPrereqs: Improve diagnostics for PrerequisiteInstaller exit code 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     is already a fully qualified domain name (FQDN). The doubled domain (server.domain.domain)
     prevented the distributed cache from starting. The domain is now only added when the
     server name is not already an FQDN (#1468).
+- SPInstallPrereqs
+  - Improved diagnostics for PrerequisiteInstaller.exe exit code 1000. This undocumented
+    failure result is now treated as a hard failure that throws an actionable error pointing
+    to the native PrerequisiteInstaller*.log and, for offline installations, to the SXSpath
+    parameter, instead of a generic unknown exit code message. Exit code 1000 no longer
+    requests a reboot (#1482).
 
 ## [5.7.1] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Resource threw an error if the Crawler Impact Rule did not exist when
     running the Get Method
 
-
 ## [5.5.0] - 2024-04-22
 
 ### Added

--- a/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -1190,6 +1190,23 @@ function Set-TargetResource
                 -Source $MyInvocation.MyCommand.Source
             throw $message
         }
+        1000
+        {
+            # ExitCode 1000 is an undocumented failure result. The actual failed
+            # prerequisite is only recorded in the native PrerequisiteInstaller*.log.
+            # It is treated as a hard failure and never triggers a reboot.
+            $message = ("The prerequisite installer failed with undocumented exit code 1000. " + `
+                    "Review the latest PrerequisiteInstaller*.log in the temporary directory " + `
+                    "of the account running this resource ($env:TEMP). For offline " + `
+                    "installations, verify SXSpath points to the SXS store from matching " + `
+                    "Windows Server installation media, or preinstall all required Windows " + `
+                    "features from that source.")
+            Add-SPDscEvent -Message $message `
+                -EntryType 'Error' `
+                -EventID 100 `
+                -Source $MyInvocation.MyCommand.Source
+            throw $message
+        }
         1001
         {
             Write-Verbose -Message ("A pending restart is blocking the prerequisite " + `

--- a/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/Readme.md
+++ b/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/Readme.md
@@ -52,3 +52,25 @@ https://docs.microsoft.com/en-us/sharepoint/install/hardware-and-software-requir
 
 SharePoint Subscription:
 https://learn.microsoft.com/en-us/sharepoint/install/software-requirements-for-sharepoint-servers-for-sharepoint-server-subscription-edition
+
+## Troubleshooting
+
+### PrerequisiteInstaller.exe exit code 1000
+
+Exit code `1000` is an undocumented failure result from the
+PrerequisiteInstaller.exe. In contrast to exit code `3010`, which Microsoft
+documents as the restart-required result, `1000` is undocumented and does
+not point to a specific cause by itself. This resource treats it as a hard
+failure: it does not retry the installation and does not request a reboot.
+
+The prerequisite that actually failed is recorded in the native
+`PrerequisiteInstaller*.log` file. This log is written to the temporary
+directory of the account that runs the resource (for example, the account
+specified through `PsDscRunAsCredential`). Review the most recent log to
+find the underlying failure.
+
+For offline installations, a common cause is a failed Windows feature
+installation because the required feature payload is missing. In that case,
+set the `SXSpath` parameter to the SXS store from Windows Server installation
+media that matches the target operating system, or preinstall all required
+Windows features from that same source.

--- a/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
+++ b/tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
@@ -270,6 +270,32 @@ try
 
                     { Set-TargetResource @testParams } | Should -Throw "Invalid command line parameters"
                 }
+
+                It "Should call the prerequisite installer from the set method and throw an actionable error for undocumented exit code 1000 without requesting a reboot" {
+                    Mock -CommandName Start-Process { return @{ ExitCode = 1000 } }
+                    Mock -CommandName Add-SPDscEvent { }
+                    $global:DSCMachineStatus = 0
+
+                    $exception = $null
+                    try
+                    {
+                        Set-TargetResource @testParams
+                    }
+                    catch
+                    {
+                        $exception = $_
+                    }
+
+                    $exception | Should -Not -BeNullOrEmpty
+                    $exception.Exception.Message | Should -Match '1000'
+                    $exception.Exception.Message | Should -Match 'PrerequisiteInstaller\*\.log'
+                    $exception.Exception.Message | Should -Match 'SXSpath'
+                    Assert-MockCalled -CommandName Start-Process -Scope It
+                    Assert-MockCalled -CommandName Add-SPDscEvent -Scope It -Times 1 -Exactly -ParameterFilter {
+                        $EntryType -eq 'Error' -and $EventID -eq 100
+                    }
+                    $global:DSCMachineStatus | Should -Be 0
+                }
             }
 
             Context -Name "Prerequisites are installed and should be" -Fixture {


### PR DESCRIPTION
#### Pull Request (PR) description

`MSFT_SPInstallPrereqs` previously handled the undocumented
`PrerequisiteInstaller.exe` exit code `1000` through the generic `default`
branch (*"The prerequisite installer ran with the following unknown exit code
1000"*). That message does not direct operators to the native
`PrerequisiteInstaller*.log`, where the actual failed prerequisite is recorded
(in the reported case, a failed IIS feature install caused by missing offline
Windows feature payloads).

This PR adds an explicit `1000` branch to the exit-code switch that:

- Treats `1000` as a hard failure — it does not retry and does not classify it
  as success or restart-required.
- Does **not** set `$global:DSCMachineStatus`, so exit code `1000` never
  requests a DSC reboot.
- Writes an error through the existing `Add-SPDscEvent` pattern
  (`EntryType 'Error'`, `EventID 100`) and throws an actionable exception that
  references exit code `1000`, `PrerequisiteInstaller*.log`, the temporary
  directory of the account running the resource, and the `SXSpath` parameter,
  with guidance to use matching Windows Server installation media or preinstall
  the required Windows features from that source.

Microsoft documents `3010` (not `1000`) as the restart-required result; that
distinction is preserved. Behavior for exit codes `0`, `1`, `2`, `1001`,
`3010`, `-1`, `-2147467259`, and the generic `default` branch is unchanged. The
change does not parse, copy, or attach native installer logs — the native log
remains the source of truth for the underlying failure. Resource
troubleshooting documentation and the changelog are updated accordingly.

#### This Pull Request (PR) fixes the following issues

- Fixes #1482

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/SharePointDsc/1483)
<!-- Reviewable:end -->
